### PR TITLE
additional iteration combinators

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -443,6 +443,11 @@ let option x p =
 
 let cons x xs = x :: xs
 
+let rec list ps =
+  match ps with
+  | []    -> return []
+  | p::ps -> cons <$> p <*> list ps
+
 let count n p =
   if n < 0 then
     failwith "count: invalid argument, n < 0";
@@ -470,10 +475,12 @@ let sep_by1 s p =
 let sep_by s p =
   (cons <$> p <*> ((s *> sep_by1 s p) <|> return [])) <|> return []
 
-let rec list ps =
-  match ps with
-  | []    -> return []
-  | p::ps -> return cons <*> p <*> list ps
+let skip_many p =
+  fix (fun m ->
+    (p *> m) <|> return ())
+
+let skip_many1 p =
+  p *> skip_many p
 
 let end_of_line =
   (char '\n' *> return ()) <|> (string "\r\n" *> return ()) <?> "end_of_line"

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -443,6 +443,15 @@ let option x p =
 
 let cons x xs = x :: xs
 
+let count n p =
+  if n < 0 then
+    failwith "count: invalid argument, n < 0";
+  let rec loop = function
+    | 0 -> return []
+    | n -> cons <$> p <*> (loop (n - 1))
+  in
+  loop n
+
 let many p =
   fix (fun m ->
     (return cons <*> p <*> m) <|> return [])

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -149,6 +149,12 @@ val sep_by : 'a t -> 'b t -> 'b list t
 val sep_by1 : 'a t -> 'b t -> 'b list t
 (** [sep_by1 s p] runs [p] {i one} or more times, interspersing runs of [s] in between. *)
 
+val skip_many : 'a t -> unit t
+(** [skip_many p] runs [p] {i zero} or more times, discarding the results.*)
+
+val skip_many1 : 'a t -> unit t
+(** [skip_many1 p] runs [p] {i one} or more times, discarding the results. *)
+
 val fix : ('a t -> 'a t) -> 'a t
 (** [fix f] computes the fixpoint of [f] and runs the resultant parser,
     returning its result. *)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -128,6 +128,9 @@ val list : 'a t list -> 'a list t
 (** [list ps] runs each [p] in [ps] in sequence, returning a list of results of
     each [p]. *)
 
+val count : int -> 'a t -> 'a list t
+(** [count n p] runs [p] [n] times, returning a list of the results. *)
+
 val many : 'a t -> 'a list t
 (** [many p] runs [p] {i zero} or more times and returns a list of results from
     the runs of [p]. *)

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -157,6 +157,12 @@ let combinators =
       check_lc ~msg:"single char"     parser ["a"]    ['a'];
       check_lc ~msg:"many chars"      parser ["a,a"]  ['a'; 'a'];
       check_lc ~msg:"no trailing sep"  parser ["a,"]   ['a'];
+  end
+  ; "count", `Quick, begin fun () ->
+    check_lc ~msg:"empty input" (count 0 (char 'a')) [""] [];
+    check_lc ~msg:"exact input" (count 1 (char 'a')) ["a"] ['a'];
+    check_lc ~msg:"additonal input" (count 2 (char 'a')) ["aaa"] ['a'; 'a'];
+    check_fail ~msg:"bad input" (count 2 (char 'a')) ["abb"];
   end ]
 
 let incremental =


### PR DESCRIPTION
This pull request adds the `count`, `skip_while` and `skip_while1` to the Angstrom API. Documentation for each can be found in the mli file.