### PR TITLE
RFC2616 bug fix and performance improvement

### DIFF
--- a/rfcs/rFC2616.ml
+++ b/rfcs/rFC2616.ml
@@ -60,7 +60,7 @@ let request_first_line =
 let response_first_line =
   (fun version status msg -> (version, status, msg))
     <$> lex version
-    <*> take_till P.is_space
+    <*> lex (take_till P.is_space)
     <*> take_till P.is_eol
 
 let header =

--- a/rfcs/rFC2616.ml
+++ b/rfcs/rFC2616.ml
@@ -4,32 +4,29 @@ module P = struct
   let is_space =
     function | ' ' | '\t' -> true | _ -> false
 
-  let is_eol c = c = '\r' || c = '\n'
+  let is_eol =
+    function | '\r' | '\n' -> true | _ -> false
 
   let is_hex =
     function | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true | _ -> false
-
-  let is_colon c = c = ':'
-
-  let is_colon_or_space c =
-    is_space c || is_colon c
 
   let is_digit =
     function '0' .. '9' -> true | _ -> false
 
   let is_separator =
-    let ss = "()<>@,;:\\\"/[]?={} \t" in
-    let len = String.length ss in
-    let rec loop c i =
-      if i >= len then false
-      else if c = String.unsafe_get ss i then true
-      else loop c (i + 1)
-    in
-    fun c -> loop c 0
+    function
+      | ')' | '(' | '<' | '>' | '@' | ',' | ';' | ':' | '\\' | '"'
+      | '/' | '[' | ']' | '?' | '=' | '{' | '}' | ' ' | '\t' -> true
+      | _ -> false
 
-  let is_token c =
-    let i = Char.code c in
-    i > 31 && i <> 127 && not (is_separator c)
+  let is_token =
+    (* The commented-out ' ' and '\t' are not necessary because of the range at
+     * the top of the match. *)
+    function
+      | '\000' .. '\031' | '\127'
+      | ')' | '(' | '<' | '>' | '@' | ',' | ';' | ':' | '\\' | '"'
+      | '/' | '[' | ']' | '?' | '=' | '{' | '}' (* | ' ' | '\t' *) -> false
+      | _ -> true
 end
 
 let token = take_while1 P.is_token


### PR DESCRIPTION
This pull request includes a bugfix in the response RFC2616 response parser, as well as a performance improvement to various components of the RFC2616 parser. Microbenchmarks suggest a 30% performance improvement for request parsing.

Here are the results of the benchmark before the patches:

```
$ ./pure_benchmark.native -q 60 +time
Estimated testing time 2m (2 benchmarks x 1m). Change using -quota SECS.
┌──────┬──────────┬──────────┬───────────────┬─────────┬──────────┬──────────┬────────────┐
│ Name │ Time R^2 │ Time/Run │          95ci │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────┼──────────┼──────────┼───────────────┼─────────┼──────────┼──────────┼────────────┤
│ json │     1.00 │  21.07ms │ -0.55% +0.55% │ 18.78Mw │ 242.08kw │ 242.08kw │     44.79% │
│ http │     1.00 │  47.05ms │ -0.31% +0.36% │ 32.06Mw │  71.01kw │  71.01kw │    100.00% │
└──────┴──────────┴──────────┴───────────────┴─────────┴──────────┴──────────┴────────────┘
```

... and here is the same benchmark after the patches:

```
$ ./pure_benchmark.native -q 60 +time
Estimated testing time 2m (2 benchmarks x 1m). Change using -quota SECS.
┌──────┬──────────┬──────────┬───────────────┬─────────┬──────────┬──────────┬────────────┐
│ Name │ Time R^2 │ Time/Run │          95ci │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────┼──────────┼──────────┼───────────────┼─────────┼──────────┼──────────┼────────────┤
│ json │     1.00 │  21.17ms │ -0.50% +0.51% │ 18.78Mw │ 242.08kw │ 242.08kw │     58.54% │
│ http │     1.00 │  36.16ms │ -0.33% +0.35% │ 32.06Mw │  71.00kw │  71.00kw │    100.00% │
└──────┴──────────┴──────────┴───────────────┴─────────┴──────────┴──────────┴────────────┘
```