### PR TITLE
lwt-unit: Use Lwt.return_unit as default pushback

### DIFF
--- a/lwt/angstrom_lwt.ml
+++ b/lwt/angstrom_lwt.ml
@@ -34,7 +34,7 @@
 open Angstrom.Buffered
 open Lwt.Infix
 
-let default_pushback () = Lwt_main.yield ()
+let default_pushback () = Lwt.return_unit
 
 let parse ?(pushback=default_pushback) p in_chan =
   let size  = Lwt_io.buffer_size in_chan in


### PR DESCRIPTION
`Lwt.yield ()` is a more preferable choice, as that would ensure that parsing thread would allow other threads to run. However, that function is exported by a module in the unix subpackage, and is therefore not portable to other platforms (JS, mirage, etc.)