### PR TITLE
Add basic little/big/native endian parsing

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -711,3 +711,46 @@ let skip_many1 p =
 
 let end_of_line =
   (char '\n' *> return ()) <|> (string "\r\n" *> return ()) <?> "end_of_line"
+
+module Make_endian(Es : EndianString.EndianStringSig) = struct
+  let get_float s = Es.get_float s 0
+  let get_double s = Es.get_double s 0
+
+  let get_int8 s = Es.get_int8 s 0
+  let get_int16 s = Es.get_int16 s 0
+  let get_int32 s = Es.get_int32 s 0
+  let get_int64 s = Es.get_int64 s 0
+
+  let get_uint8 s = Es.get_uint8 s 0
+  let get_uint16 s = Es.get_uint16 s 0
+  let get_uint32 s = Es.get_int32 s 0
+  let get_uint64 s = Es.get_int64 s 0
+
+  (* int *)
+  let uint8 =
+    take 1 >>| get_uint8
+  let uint16 =
+    take 2 >>| get_uint16
+  let uint32 =
+    take 4 >>| get_uint32
+  let uint64 =
+    take 8 >>| get_uint64
+  let int8 =
+    take 1 >>| get_int8
+  let int16 =
+    take 2 >>| get_int16
+  let int32 =
+    take 4 >>| get_int32
+  let int64 =
+    take 8 >>| get_int64
+
+  (* float *)
+  let float =
+    take 4 >>| get_float
+  let double =
+    take 8 >>| get_double
+end
+
+module Le = Make_endian(EndianString.LittleEndian_unsafe)
+module Be = Make_endian(EndianString.BigEndian_unsafe)
+module Ne = Make_endian(EndianString.NativeEndian_unsafe)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -130,6 +130,87 @@ val end_of_line : unit t
     followed by a line feed [\r\n] and returns unit. *)
 
 
+(** {2 Little/Big/Native endian parsers} *)
+
+module Le : sig
+  (** {2 Little endian parsers} *)
+
+  val int8 : int t
+  val int16 : int t
+  val int32 : int32 t
+  val int64 : int64 t
+  (** [intN] reads [N] bits and interprets them as a signed, little endian
+      integer. *)
+
+  val uint8 : int t
+  val uint16 : int t
+  val uint32 : int32 t
+  val uint64 : int64 t
+  (** [uintN] reads [N] bits and interprets them as an unsigned, little endian
+      integer. *)
+
+  val float : float t
+  (** [float] reads four bytes and interprets them as a little endian floating
+      point value. *)
+
+  val double : float t
+  (** [double] reads eight bytes and interprets them as a little endian floating
+      point value. *)
+end
+
+module Be : sig
+  (** {2 Big endian parsers} *)
+
+  val int8 : int t
+  val int16 : int t
+  val int32 : int32 t
+  val int64 : int64 t
+  (** [intN] reads [N] bits and interprets them as a signed, big endian
+      integer. *)
+
+  val uint8 : int t
+  val uint16 : int t
+  val uint32 : int32 t
+  val uint64 : int64 t
+  (** [uintN] reads [N] bits and interprets them as an unsigned, big endian
+      integer. *)
+
+  val float : float t
+  (** [float] reads four bytes and interprets them as a big endian floating
+      point value. *)
+
+  val double : float t
+  (** [double] reads eight bytes and interprets them as a big endian floating
+      point value. *)
+end
+
+module Ne : sig
+  (** {2 Native endian parsers} *)
+
+  val int8 : int t
+  val int16 : int t
+  val int32 : int32 t
+  val int64 : int64 t
+  (** [intN] reads [N] bits and interprets them as a signed, native endian
+      integer. *)
+
+  val uint8 : int t
+  val uint16 : int t
+  val uint32 : int32 t
+  val uint64 : int64 t
+  (** [uintN] reads [N] bits and interprets them as an unsigned, native endian
+      integer. *)
+
+  val float : float t
+  (** [float] reads four bytes and interprets them as a native endian floating
+      point value. *)
+
+  val double : float t
+  (** [double] reads eight bytes and interprets them as a native endian floating
+      point value. *)
+end
+
+
 (** {2 Combinators} *)
 
 val option : 'a -> 'a t -> 'a t

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -59,6 +59,28 @@ let check_lc ?size ~msg p is r = check_ok ?size ~msg Alcotest.(list char)     p 
 let check_co ?size ~msg p is r = check_ok ?size ~msg Alcotest.(option char)   p is r
 let check_s  ?size ~msg p is r = check_ok ?size ~msg Alcotest.string          p is r
 let check_ls ?size ~msg p is r = check_ok ?size ~msg Alcotest.(list string)   p is r
+let check_int ?size ~msg p is r = check_ok ?size ~msg Alcotest.int            p is r
+let check_int32 ?size ~msg p is r =
+  let module Alco_int32 = struct
+    type t = int32
+    let pp = Fmt.int32
+    let equal (a : int32) (b : int32) = compare a b = 0
+  end in
+  check_ok ?size ~msg (module Alco_int32) p is r
+let check_int64 ?size ~msg p is r =
+  let module Alco_int64 = struct
+    type t = int64
+    let pp = Fmt.int64
+    let equal (a : int64) (b : int64) = compare a b = 0
+  end in
+  check_ok ?size ~msg (module Alco_int64) p is r
+let check_float ?size ~msg p is r =
+  let module Alco_float = struct
+    type t = float
+    let pp = Fmt.float
+    let equal (a : float) (b : float) = compare a b = 0
+  end in
+  check_ok ?size ~msg (module Alco_float) p is r
 
 let basic_constructors =
   [ "peek_char", `Quick, begin fun () ->
@@ -112,6 +134,123 @@ let basic_constructors =
       check_s ~msg:"false, empty input"     (take_while (fun _ -> false)) [""] "";
   end
   ]
+
+module Endian(Es : EndianString.EndianStringSig) = struct
+  type 'a endian = {
+    name : string;
+    size : int;
+    zero : 'a;
+    min : 'a;
+    max : 'a;
+    set : Bytes.t -> int -> 'a -> unit;
+    get : string -> int -> 'a;
+    check : ?size:int -> msg:string -> 'a Angstrom.t -> string list -> 'a -> unit;
+  }
+
+  let int8 = {
+    name = "int8";
+    size = 1;
+    zero = 0;
+    min = ~-128;
+    max = 127;
+    set = Es.set_int8;
+    get = Es.get_int8;
+    check = check_int;
+  }
+  let int16 = {
+    name = "int16";
+    size = 2;
+    zero = 0;
+    min = ~-32768;
+    max = 32767;
+    set = Es.set_int16;
+    get = Es.get_int16;
+    check = check_int;
+  }
+  let int32 = {
+    name = "int32";
+    size = 4;
+    zero = Int32.zero;
+    min = Int32.min_int;
+    max = Int32.max_int;
+    set = Es.set_int32;
+    get = Es.get_int32;
+    check = check_int32;
+  }
+  let int64 = {
+    name = "int64";
+    size = 8;
+    zero = Int64.zero;
+    min = Int64.min_int;
+    max = Int64.max_int;
+    set = Es.set_int64;
+    get = Es.get_int64;
+    check = check_int64;
+  }
+  let float = {
+    name = "float";
+    size = 4;
+    zero = 0.0;
+    (* XXX: Not really min/max *)
+    min = ~-.2e10;
+    max = 2e10;
+    set = Es.set_float;
+    get = Es.get_float;
+    check = check_float;
+  }
+  let double = {
+    name = "double";
+    size = 8;
+    zero = 0.0;
+    (* XXX: Not really min/max *)
+    min = ~-.2e30;
+    max = 2e30;
+    set = Es.set_double;
+    get = Es.get_double;
+    check = check_float;
+  }
+
+  let uint8 = { int8 with name = "uint8"; min = 0; max = 255 }
+  let uint16 = { int16 with name = "uint16"; min = 0; max = 65535 }
+  let uint32 = { int32 with name = "uint32" }
+  let uint64 = { int64 with name = "uint64" }
+
+  let to_string e x =
+    let buf = Bytes.create e.size in
+    e.set buf 0 x;
+    buf
+
+  let make_tests e parse = e.name, `Quick, begin fun () ->
+    e.check ~msg:"zero"     parse [to_string e e.zero]          e.zero;
+    e.check ~msg:"min"      parse [to_string e e.min]           e.min;
+    e.check ~msg:"max"      parse [to_string e e.max]           e.max;
+    e.check ~msg:"trailing" parse [to_string e e.zero ^ "\xff"] e.zero;
+  end
+
+  module type EndianSig = module type of Le
+
+  let tests (module E : EndianSig) = [
+    make_tests int8   E.int8;
+    make_tests int16  E.int16;
+    make_tests int32  E.int32;
+    make_tests int64  E.int64;
+    make_tests uint8  E.uint8;
+    make_tests uint16 E.uint16;
+    make_tests uint32 E.uint32;
+    make_tests uint64 E.uint64;
+    make_tests float  E.float;
+    make_tests double E.double;
+  ]
+end
+let little_endian =
+  let module E = Endian(EndianString.LittleEndian) in
+  E.tests (module Le)
+let big_endian =
+  let module E = Endian(EndianString.BigEndian) in
+  E.tests (module Be)
+let native_endian =
+  let module E = Endian(EndianString.NativeEndian) in
+  E.tests (module Ne)
 
 let monadic =
   [ "fail", `Quick, begin fun () ->
@@ -192,6 +331,9 @@ let incremental =
 let () =
   Alcotest.run "test suite"
     [ "basic constructors"    , basic_constructors
+    ; "little endian"         , little_endian
+    ; "big endian"            , big_endian
+    ; "native endian"         , native_endian
     ; "monadic interface"     , monadic
     ; "applicative interface" , applicative
     ; "alternative"           , alternative

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -63,21 +63,21 @@ let check_int ?size ~msg p is r = check_ok ?size ~msg Alcotest.int            p 
 let check_int32 ?size ~msg p is r =
   let module Alco_int32 = struct
     type t = int32
-    let pp = Fmt.int32
+    let pp fmt i = Format.pp_print_string fmt (Int32.to_string i)
     let equal (a : int32) (b : int32) = compare a b = 0
   end in
   check_ok ?size ~msg (module Alco_int32) p is r
 let check_int64 ?size ~msg p is r =
   let module Alco_int64 = struct
     type t = int64
-    let pp = Fmt.int64
+    let pp fmt i = Format.pp_print_string fmt (Int64.to_string i)
     let equal (a : int64) (b : int64) = compare a b = 0
   end in
   check_ok ?size ~msg (module Alco_int64) p is r
 let check_float ?size ~msg p is r =
   let module Alco_float = struct
     type t = float
-    let pp = Fmt.float
+    let pp fmt f = Format.pp_print_string fmt (string_of_float f)
     let equal (a : float) (b : float) = compare a b = 0
   end in
   check_ok ?size ~msg (module Alco_float) p is r


### PR DESCRIPTION
For #22

A few notes:
- If I understand correctly the `_unsafe` modules should be ok to use
  here since the number of bytes is restricted in the wrappers around
  the EndianString.* functions.
- The Make_endian functor may add some overhead on compilers without
  flambda enabled/available.  I used a functor here anyway to avoid lots
  of copying and pasting.  The interface is duplicated because it makes
  the generated documentation easier to read but that duplication could
  be eliminated with a module type defintion.
- If the source is a cstruct then EndianBigString.* working directly
  with the cstruct-wrapped bigarrays could avoid lots of string
  allocations from the `take` calls.

No tests or benchmarks yet - I'd like to agree on naming and basic implementation first.