### PR TITLE
Advance

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -469,10 +469,10 @@ let ensure_suspended n input pos more fail succ =
       if pos' + n <= Input.length input' then
         succ' input' pos' more' ()
       else
-        (demand_input >>= fun () -> go).run input' pos' more' fail' succ'
+        (demand_input *> go).run input' pos' more' fail' succ'
     }
   in
-  (demand_input >>= fun () -> go).run input pos more fail succ
+  (demand_input *> go).run input pos more fail succ
 
 let unsafe_substring n =
   { run = fun input pos more fail succ ->
@@ -486,7 +486,7 @@ let ensure n =
     else
       ensure_suspended n input pos more fail succ
   }
-  >>= fun () -> unsafe_substring n
+  *> unsafe_substring n
 
 
 (** END: getting input *)

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -476,7 +476,7 @@ let ensure_suspended n input pos more fail succ =
 
 let unsafe_substring n =
   { run = fun input pos more fail succ ->
-    succ input pos more (Input.substring input pos n)
+    succ input (pos + n) more (Input.substring input pos n)
   }
 
 let ensure n =
@@ -588,7 +588,7 @@ let string_ f s =
   let len = String.length s in
   ensure len >>= fun s'->
     if f s = f s'
-      then advance len *> return s'
+      then return s'
       else fail "string"
 
 let string s    = string_ (fun x -> x) s
@@ -598,16 +598,10 @@ let skip_while f =
   count_while f >>= advance
 
 let take n =
-  let n = max n 0 in
-  ensure  n >>= fun str ->
-  advance n >>| fun () ->
-    str
+  ensure (max n 0)
 
 let take_while f =
-  count_while f >>= fun n ->
-  unsafe_substring n >>= fun str ->
-  advance n >>| fun () ->
-    str
+  count_while f >>= unsafe_substring
 
 let take_while1 f =
   end_of_buffer
@@ -621,10 +615,7 @@ let take_while1 f =
     if init = 0 then
       fail "take_while1"
     else
-      count_while ~init f >>= fun n ->
-      unsafe_substring n >>= fun str ->
-      advance n >>| fun () ->
-        str
+      count_while ~init f >>= unsafe_substring
 
 let take_till f =
   take_while (fun c -> not (f c))
@@ -635,8 +626,7 @@ let take_rest =
       | true  ->
         available >>= fun n ->
         unsafe_substring n >>= fun str ->
-        advance n >>= fun () ->
-          go (str::acc)
+        go (str::acc)
       | false ->
         return (List.rev acc)
   in


### PR DESCRIPTION
This pull request eliminates several unnecessary closure allocations related to returning strings to the user. Most importantly, the `unsafe_substring` parser now advances the position of the input automatically, eliminating the need for the `advance` parser to be used in conjuction with `unsafe_substring`, along with several `bind`s. Before:
```
$ ./pure_benchmark.native +time
Estimated testing time 1.33333m (8 benchmarks x 10s). Change using -quota SECS.
┌──────────┬──────────┬──────────┬───────────────┬─────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │ Time/Run │          95ci │     mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼──────────┼───────────────┼─────────────┼──────────┼──────────┼────────────┤
│ json     │     1.00 │  16.80ms │ -0.82% +0.96% │ 12_759.06kw │ 216.56kw │ 216.56kw │     56.83% │
│ http     │     1.00 │  29.55ms │ -1.40% +1.27% │ 19_324.13kw │  60.15kw │  60.15kw │    100.00% │
│ int8 le  │     0.98 │  15.81ms │ -1.95% +1.93% │  4_587.66kw │ 571.46kw │ 571.46kw │     53.49% │
│ int64 le │     0.99 │   1.24ms │ -1.20% +1.20% │    606.34kw │  57.89kw │  57.89kw │      4.19% │
│ int8 be  │     0.95 │  13.60ms │ -4.21% +5.42% │  4_587.66kw │ 569.61kw │ 569.61kw │     46.01% │
│ int64 be │     0.99 │   1.18ms │ -1.12% +1.12% │    606.34kw │  57.88kw │  57.88kw │      4.01% │
│ int8 ne  │     0.96 │  11.20ms │ -4.17% +4.17% │  4_587.66kw │ 566.97kw │ 566.97kw │     37.90% │
│ int64 ne │     0.99 │   1.15ms │ -0.95% +1.03% │    606.34kw │  57.89kw │  57.89kw │      3.87% │
└──────────┴──────────┴──────────┴───────────────┴─────────────┴──────────┴──────────┴────────────┘
```
After:
```
$ ./pure_benchmark.native +time
Estimated testing time 1.33333m (8 benchmarks x 10s). Change using -quota SECS.
┌──────────┬──────────┬─────────────┬───────────────┬─────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │    Time/Run │          95ci │     mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼─────────────┼───────────────┼─────────────┼──────────┼──────────┼────────────┤
│ json     │     1.00 │ 16_229.19us │ -0.86% +0.98% │ 11_694.02kw │ 213.75kw │ 213.75kw │     64.83% │
│ http     │     1.00 │ 25_033.08us │ -0.80% +0.79% │ 13_384.76kw │  56.45kw │  56.45kw │    100.00% │
│ int8 le  │     0.94 │ 10_292.28us │ -4.99% +5.33% │  2_031.77kw │ 551.57kw │ 551.57kw │     41.11% │
│ int64 le │     0.99 │    818.97us │ -0.88% +0.87% │    286.83kw │  40.06kw │  40.06kw │      3.27% │
│ int8 be  │     1.00 │ 10_561.27us │ -1.18% +1.18% │  2_031.77kw │ 551.57kw │ 551.57kw │     42.19% │
│ int64 be │     0.99 │    799.88us │ -0.69% +0.72% │    286.83kw │  40.05kw │  40.05kw │      3.20% │
│ int8 ne  │     0.99 │ 10_873.46us │ -1.56% +1.42% │  2_031.77kw │ 551.17kw │ 551.17kw │     43.44% │
│ int64 ne │     0.99 │    804.06us │ -0.81% +0.85% │    286.83kw │  40.05kw │  40.05kw │      3.21% │
└──────────┴──────────┴─────────────┴───────────────┴─────────────┴──────────┴──────────┴────────────┘
```
