### PR TITLE
take_while1: rely on take_while entirely for its implementation

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -503,11 +503,6 @@ let end_of_input =
       prompt input pos fail' succ'
   }
 
-let end_of_buffer =
-  { run = fun input pos more fail succ ->
-    succ input pos more (pos = Input.length input)
-  }
-
 let advance n =
   { run = fun input pos more _fail succ -> succ input (pos + n) more () }
 
@@ -604,18 +599,10 @@ let take_while f =
   count_while f >>= unsafe_substring
 
 let take_while1 f =
-  end_of_buffer
-  >>= begin function
-    | true  -> demand_input
-    | false -> return ()
-  end >>= fun () ->
-  get_buffer_and_pos
-  >>= fun (input, pos) ->
-    let init = Input.count_while input pos f in
-    if init = 0 then
-      fail "take_while1"
-    else
-      count_while ~init f >>= unsafe_substring
+  count_while f
+  >>= function
+    | 0 -> fail "take_while1"
+    | n -> unsafe_substring n
 
 let take_till f =
   take_while (fun c -> not (f c))


### PR DESCRIPTION
The previous version was optimizing for a case where the input would be read in chunks, which would then be concatenated and then returned to the user. No such case exists for this library, so the more straightforward implementation turns out to be the faster one.

Before:

```
┌──────────┬──────────┬─────────────┬───────────────┬─────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │    Time/Run │          95ci │     mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼─────────────┼───────────────┼─────────────┼──────────┼──────────┼────────────┤
│ json     │     1.00 │ 16_399.20us │ -0.82% +0.84% │ 11_694.02kw │ 213.75kw │ 213.75kw │     65.36% │
│ http     │     1.00 │ 25_089.50us │ -0.54% +0.56% │ 13_384.76kw │  56.45kw │  56.45kw │    100.00% │
│ int8 le  │     0.94 │ 10_200.64us │ -4.98% +5.21% │  2_031.77kw │ 551.57kw │ 551.57kw │     40.66% │
│ int64 le │     0.99 │    820.99us │ -0.91% +0.97% │    286.83kw │  40.06kw │  40.06kw │      3.27% │
│ int8 be  │     0.99 │ 10_589.91us │ -1.24% +1.22% │  2_031.77kw │ 551.17kw │ 551.17kw │     42.21% │
│ int64 be │     0.99 │    812.07us │ -0.75% +0.79% │    286.83kw │  40.06kw │  40.06kw │      3.24% │
│ int8 ne  │     0.99 │ 10_656.70us │ -1.95% +2.25% │  2_031.77kw │ 551.17kw │ 551.17kw │     42.47% │
│ int64 ne │     0.99 │    808.12us │ -0.87% +0.90% │    286.83kw │  40.05kw │  40.05kw │      3.22% │
└──────────┴──────────┴─────────────┴───────────────┴─────────────┴──────────┴──────────┴────────────┘
```

After:

```
┌──────────┬──────────┬─────────────┬───────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │    Time/Run │          95ci │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼─────────────┼───────────────┼────────────┼──────────┼──────────┼────────────┤
│ json     │     1.00 │ 14_956.94us │ -0.80% +1.05% │ 9_538.74kw │ 208.12kw │ 208.12kw │     67.91% │
│ http     │     1.00 │ 22_024.47us │ -0.59% +0.67% │ 9_502.92kw │  54.17kw │  54.17kw │    100.00% │
│ int8 le  │     0.94 │ 10_223.82us │ -5.00% +5.10% │ 2_031.77kw │ 551.57kw │ 551.57kw │     46.42% │
│ int64 le │     0.99 │    837.98us │ -0.84% +0.91% │   286.83kw │  40.04kw │  40.04kw │      3.80% │
│ int8 be  │     1.00 │ 10_556.35us │ -1.06% +1.10% │ 2_031.77kw │ 551.17kw │ 551.17kw │     47.93% │
│ int64 be │     0.99 │    819.39us │ -0.91% +0.92% │   286.83kw │  40.06kw │  40.06kw │      3.72% │
│ int8 ne  │     0.99 │ 10_567.91us │ -1.37% +1.50% │ 2_031.77kw │ 551.17kw │ 551.17kw │     47.98% │
│ int64 ne │     0.99 │    799.74us │ -1.01% +1.20% │   286.83kw │  40.05kw │  40.05kw │      3.63% │
└──────────┴──────────┴─────────────┴───────────────┴────────────┴──────────┴──────────┴────────────┘
```