### PR TITLE
improve json parsing performance and memory-efficiency

### DIFF
--- a/rfcs/rFC7159.ml
+++ b/rfcs/rFC7159.ml
@@ -26,59 +26,99 @@ let _true  : json t = string "true"  *> return `True
 let _null  : json t = string "null"  *> return `Null
 
 let num =
-  let chars = take_while1 (function
+  take_while1 (function
     | '\x20' | '\x0a' | '\x0d' | '\x09'
     | '[' | ']' | '{' | '}' | ':' | ',' -> false
     | _               -> true)
-  in
-  chars
   >>= fun s ->
-    try return (`Number (float_of_string s))
-    with _ -> fail "number"
+  try return (`Number (float_of_string s))
+  with _ -> fail "number"
 
-let hex =
-  satisfy (function
-    | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
-    | _ -> false)
+module S = struct
+  type t =
+    | Unescaped
+    | Escaped
+    | Unicode of char list
+    | Error   of string
+    | Done
 
-let _str =
-  let esc = char '\x5c' in
-  let unescaped =
-    (* not '"' nor '\' *)
-    take_while1 (function | '"' | '\x5c' -> false | _ -> true) <?> "unescaped char"
-  in
-  let escaped =
-    begin esc *> any_char
-    >>= function
-      | '\x22' -> return "\x22"
-      | '\x5c' -> return "\x5c"
-      | '\x2f' -> return "\x2f"
-      | '\x62' -> return "\x08"
-      | '\x66' -> return "\x0c"
-      | '\x6e' -> return "\x0a"
-      | '\x72' -> return "\x0d"
-      | '\x74' -> return "\x09"
-      | '\x75' ->
-        lift4 (fun a b c d ->
-          Printf.sprintf "%c%c"
-            Char.(chr (0x10 * (code a) + (code b)))
-            Char.(chr (0x10 * (code c) + (code d))))
-          hex hex hex hex
-      | _     -> fail "invalid escape sequence"
-    end <?> "escaped char"
-  in
-  let chars = many (unescaped <|> escaped) >>| String.concat "" in
-  chars <* char '"'
+  let to_string = function
+    | Unescaped -> "unescaped"
+    | Escaped   -> "escaped"
+    | Unicode _ -> "unicode _"
+    | Error e   -> Printf.sprintf "error %S" e
+    | Done      -> "done"
 
-let str =
-  (_str >>| fun s -> `String s) <?> "str"
+  let unescaped buf = function
+    | '"'  -> Some Done
+    | '\\' -> Some Escaped
+    | c    -> Buffer.add_char buf c; Some Unescaped
+
+  let escaped buf = function
+    | '\x22' -> Buffer.add_char buf '\x22'; Some Unescaped
+    | '\x5c' -> Buffer.add_char buf '\x5c'; Some Unescaped
+    | '\x2f' -> Buffer.add_char buf '\x2f'; Some Unescaped
+    | '\x62' -> Buffer.add_char buf '\x08'; Some Unescaped
+    | '\x66' -> Buffer.add_char buf '\x0c'; Some Unescaped
+    | '\x6e' -> Buffer.add_char buf '\x0a'; Some Unescaped
+    | '\x72' -> Buffer.add_char buf '\x0d'; Some Unescaped
+    | '\x74' -> Buffer.add_char buf '\x09'; Some Unescaped
+    | '\x75' -> Some (Unicode [])
+    | _      -> Some (Error "invalid escape sequence")
+
+  let hex c =
+    match c with
+    | '0' .. '9' -> Char.code c - 0x30 (* '0' *)
+    | 'a' .. 'f' -> Char.code c - 87
+    | 'A' .. 'F' -> Char.code c - 55
+    | _          -> 255
+
+  let unicode buf d = function
+    | [c;b;a] ->
+      let a = hex a and b = hex b and c = hex c and d = hex d in
+      if a lor b lor c lor d = 255 then
+        Some (Error "invalid hex escape")
+      else begin
+        Buffer.add_char buf Char.(unsafe_chr @@ (a lsl 4) + b);
+        Buffer.add_char buf Char.(unsafe_chr @@ (c lsl 4) + d);
+        Some Unescaped
+      end
+    | cs -> Some (Unicode (d::cs))
+
+  let str buf =
+    let state = ref Unescaped in
+    skip_while (fun c ->
+      match
+        begin match !state with
+        | Unescaped  -> unescaped buf c
+        | Escaped    -> escaped   buf c
+        | Unicode cs -> unicode   buf c cs
+        | (Error _ | Done) -> None
+        end
+      with
+        | Some (Error _) | None -> false
+        | Some state' -> state := state'; true)
+    >>= fun () ->
+      match !state with
+      | Done        ->
+        let result = Buffer.contents buf in
+        Buffer.clear buf;
+        state := Unescaped;
+        return result
+      | Error msg ->
+        Buffer.clear buf; state := Unescaped; fail msg
+      | Unescaped | Escaped | Unicode _ ->
+        Buffer.clear buf; state := Unescaped; fail "unterminated string"
+end
 
 let json =
   let pair x y = (x, y) in
+  let buf = Buffer.create 0x1000 in
   fix (fun json ->
-    let member = lift2 pair (quo *> _str <* ns) json in
-    let obj = sep_by vs member <* rcb >>| fun ms -> `Object ms in
-    let arr = sep_by vs json   <* rsb >>| fun vs -> `Array  vs in
+    let mem = lift2 pair (quo *> S.str buf <* ns) json in
+    let obj = sep_by vs mem  <* rcb >>| fun ms -> `Object ms in
+    let arr = sep_by vs json <* rsb >>| fun vs -> `Array  vs in
+    let str = S.str buf >>| fun s -> `String s in
     ws *> peek_char_fail
     >>= function
       | 'f' -> _false


### PR DESCRIPTION
This pull request improves the performance and memory-efficiency of the JSON parser provided in the `rfcs` directory of the repository. The main performance gain is due to a new approach to parsing strings, which does not allocate intermediate strings, and does not rely on backtracking.

Before:

```
┌──────┬──────────┬──────────┬───────────────┬─────────┬──────────┬──────────┬────────────┐
│ Name │ Time R^2 │ Time/Run │          95ci │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────┼──────────┼──────────┼───────────────┼─────────┼──────────┼──────────┼────────────┤
│ json │     1.00 │  15.98ms │ -1.25% +1.05% │  9.54Mw │ 208.07kw │ 208.07kw │    100.00% │
└──────┴──────────┴──────────┴───────────────┴─────────┴──────────┴──────────┴────────────┘
```

After:
```
┌──────┬──────────┬──────────┬───────────────┬─────────┬──────────┬──────────┬────────────┐
│ Name │ Time R^2 │ Time/Run │          95ci │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────┼──────────┼──────────┼───────────────┼─────────┼──────────┼──────────┼────────────┤
│ json │     1.00 │  13.27ms │ -0.82% +0.91% │  5.17Mw │ 195.96kw │ 195.96kw │    100.00% │
└──────┴──────────┴──────────┴───────────────┴─────────┴──────────┴──────────┴────────────┘
```