### PR TITLE
char: reduce allocations from use of char parser

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -72,16 +72,16 @@ val not_char : char -> char t
 val any_char : char t
 (** [any_char] accepts any character and returns it. *)
 
+val satisfy : (char -> bool) -> char t
+(** [satisfy f] accepts any character for which [f] returns [true] and returns
+    the accepted character. *)
+
 val string : string -> string t
 (** [string s] accepts [s] exactly and returns it. *)
 
 val string_ci : string -> string t
 (** [string_ci s] accepts [s], ignoring case, and returns the matched string,
     preserving the case of the original input. *)
-
-val satisfy : (char -> bool) -> char t
-(** [satisfy f] accepts any character for which [f] returns [true] and returns
-    the accepted character. *)
 
 val skip : (char -> bool) -> unit t
 (** [skip f] accepts any character for which [f] returns [true] and discards


### PR DESCRIPTION
The char parsers as implemented previously required the use of binds, leading to unnecessary allocations of intermediate parser and therefore closures. With this patch the new char parsers (with the exception of `peek_char`) are built from a single `_char` primitive parser. This parser requires that there is at least one more character in the input, and fails otherwise. Its function argument is applied to the character and and transforms it to an optional value. If the function returns `Some v` then parser succeeds with value `v`, and fails otherwise.

Before:
```
┌──────────┬──────────┬─────────────┬───────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │    Time/Run │          95ci │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼─────────────┼───────────────┼────────────┼──────────┼──────────┼────────────┤
│ json     │     0.99 │ 12_412.71us │ -1.58% +1.73% │ 5_165.38kw │ 195.91kw │ 195.91kw │     55.84% │
│ http     │     1.00 │ 22_228.98us │ -0.63% +0.59% │ 9_502.92kw │  54.17kw │  54.17kw │    100.00% │
└──────────┴──────────┴─────────────┴───────────────┴────────────┴──────────┴──────────┴────────────┘
```

After:
```
┌──────────┬──────────┬─────────────┬───────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name     │ Time R^2 │    Time/Run │          95ci │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼──────────┼─────────────┼───────────────┼────────────┼──────────┼──────────┼────────────┤
│ json     │     1.00 │ 11_029.55us │ -1.06% +1.14% │ 3_808.19kw │ 191.11kw │ 191.11kw │     52.76% │
│ http     │     1.00 │ 20_906.23us │ -0.53% +0.60% │ 8_185.90kw │  53.03kw │  53.03kw │    100.00% │
└──────────┴──────────┴─────────────┴───────────────┴────────────┴──────────┴──────────┴────────────┘
```