### PR TITLE
peek_string: add support for unbounded lookahead

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Feature \ Library                   | Angstrom | [mparser] | [planck] | [opal] |
 ------------------------------------|:--------:|:---------:|:--------:|:------:|
 Monadic interface                   | ✅        | ✅         | ✅        | ✅      |
 Backtracking by default             | ✅        | ❌         | ❌        | ❌      |
-Unbounded lookahead                 | ❌        | ✅         | ✅        | ❌      |
+Unbounded lookahead                 | ✅        | ✅         | ✅        | ❌      |
 Reports line numbers in errors      | ❌        | ✅         | ❌        | ❌      |
 Efficient `take_while`/`skip_while` | ✅        | ❌         | ❌        | ❌      |
 Unbuffered (zero-copy) interface    | ✅        | ❌         | ❌        | ❌      |

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -611,6 +611,9 @@ let skip_while f =
 let take n =
   ensure (max n 0)
 
+let peek_string n =
+  unsafe_lookahead (take n)
+
 let take_while f =
   count_while f >>= unsafe_substring
 

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -51,14 +51,20 @@ type 'a t
 (** {2 Basic parsers} *)
 
 val peek_char : char option t
-(** [peek_char] matches any char and returns it, or returns [None] if the end
+(** [peek_char] accepts any char and returns it, or returns [None] if the end
     of input has been reached.
 
     This parser does not advance the input. Use it for lookahead. *)
 
 val peek_char_fail : char t
-(** [peek_char_fail] matches any char and returns it. If end of input has been
+(** [peek_char_fail] accepts any char and returns it. If end of input has been
     reached, it will fail.
+
+    This parser does not advance the input. Use it for lookahead. *)
+
+val peek_string : int -> string t
+(** [peek_string n] accepts exactly [n] characters and returns them as a
+    string. If there is not enough input, it will fail.
 
     This parser does not advance the input. Use it for lookahead. *)
 


### PR DESCRIPTION
Note that it may be useful to use `peek_string` in conjunction with `parse_only` if there is a need to extract some structure from the lookahead range.