### PR TITLE
committed: clarify consumed vs committed

### DIFF
--- a/async/angstrom_async.ml
+++ b/async/angstrom_async.ml
@@ -52,8 +52,9 @@ let rec finalize state result =
   | state    , _                           -> state_to_result state
 
 let response = function
-  | Partial p -> `Consumed(p.committed, `Need_unknown)
-  | _         -> `Stop ()
+  | Partial p  -> `Consumed(p.committed, `Need_unknown)
+  | Done(_, c) -> `Stop_consumed((), c)
+  | Fail _     -> `Stop ()
 
 let default_pushback () = Deferred.unit
 

--- a/async/angstrom_async.ml
+++ b/async/angstrom_async.ml
@@ -52,7 +52,7 @@ let rec finalize state result =
   | state    , _                           -> state_to_result state
 
 let response = function
-  | Partial p -> `Consumed(p.consumed, `Need_unknown)
+  | Partial p -> `Consumed(p.committed, `Need_unknown)
   | _         -> `Stop ()
 
 let default_pushback () = Deferred.unit

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -412,8 +412,8 @@ module Buffered : sig
 
   type 'a state =
     | Partial of ([ input | `Eof ] -> 'a state) (** The parser requires more input. *)
-    | Done    of unconsumed * 'a (** The parser succeeded. *)
-    | Fail    of unconsumed * string list * string (** The parser failed. *)
+    | Done    of 'a * unconsumed (** The parser succeeded. *)
+    | Fail    of string list * string * unconsumed (** The parser failed. *)
 
   val parse : ?initial_buffer_size:int -> ?input:input -> 'a t -> 'a state
   (** [parse ?initial_buffer_size ?input t] runs [t] on [input], if present,

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -472,7 +472,7 @@ module Unbuffered : sig
 
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
-    | Done    of 'a (** The parser succeeded. *)
+    | Done    of 'a * int (** The parser succeeded, consuming specified bytes. *)
     | Fail    of string list * string (** The parser failed. *)
   and 'a partial =
     { committed : int

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -475,13 +475,13 @@ module Unbuffered : sig
     | Done    of 'a (** The parser succeeded. *)
     | Fail    of string list * string (** The parser failed. *)
   and 'a partial =
-    { consumed : int
-      (** The number of bytes consumed during the last input feeding.
+    { committed : int
+      (** The number of bytes committed during the last input feeding.
           Callers must drop this number of bytes from the beginning of the
-          input on subsequent calls. *)
+          input on subsequent calls. See {!commit} for additional details. *)
     ; continue : input -> more -> 'a state
       (** A continuation of a parse that requires additional input. The input
-          should include all unconsumed input (as reported by previous partial
+          should include all uncommitted input (as reported by previous partial
           states) in addition to any new input that has become available, as
           well as an indication of whether there is {!more} input to come.  *)
     }


### PR DESCRIPTION
This pull request clarifies the use of the use of the terms "commit" and "consume" in the API. A parser may consume input but still retain the ability to backtrack. A parser however cannot backtrack beyond a commit point.

In addition, this pull request reports the parser's position upon completing a successful parse, something that is important to report if it has not consumed all of its input.