### PR TITLE
endian: drop certain endian parsers

### DIFF
--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -42,11 +42,8 @@ let main () =
       match Angstrom.(parse_only (skip_many RFC2616.request) (`String http_get)) with
       | R.Ok _ -> ()
       | R.Error err -> failwith err);
-    make_endian "int8 le" Angstrom.Le.int8;
     make_endian "int64 le" Angstrom.Le.int64;
-    make_endian "int8 be" Angstrom.Be.int8;
     make_endian "int64 be" Angstrom.Be.int64;
-    make_endian "int8 ne" Angstrom.Ne.int8;
     make_endian "int64 ne" Angstrom.Ne.int64;
   ])
 

--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -44,7 +44,6 @@ let main () =
       | R.Error err -> failwith err);
     make_endian "int64 le" Angstrom.Le.int64;
     make_endian "int64 be" Angstrom.Be.int64;
-    make_endian "int64 ne" Angstrom.Ne.int64;
   ])
 
 let () = main ()

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -749,4 +749,3 @@ end
 
 module Le = Make_endian(EndianString.LittleEndian_unsafe)
 module Be = Make_endian(EndianString.BigEndian_unsafe)
-module Ne = Make_endian(EndianString.NativeEndian_unsafe)

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -702,12 +702,10 @@ let end_of_line =
   (char '\n' *> return ()) <|> (string "\r\n" *> return ()) <?> "end_of_line"
 
 module type I = sig
-  val int8 : int t
   val int16 : int t
   val int32 : int32 t
   val int64 : int64 t
 
-  val uint8 : int t
   val uint16 : int t
   val uint32 : int32 t
   val uint64 : int64 t
@@ -720,27 +718,21 @@ module Make_endian(Es : EndianString.EndianStringSig) : I = struct
   let get_float s = Es.get_float s 0
   let get_double s = Es.get_double s 0
 
-  let get_int8 s = Es.get_int8 s 0
   let get_int16 s = Es.get_int16 s 0
   let get_int32 s = Es.get_int32 s 0
   let get_int64 s = Es.get_int64 s 0
 
-  let get_uint8 s = Es.get_uint8 s 0
   let get_uint16 s = Es.get_uint16 s 0
   let get_uint32 s = Es.get_int32 s 0
   let get_uint64 s = Es.get_int64 s 0
 
   (* int *)
-  let uint8 =
-    take 1 >>| get_uint8
   let uint16 =
     take 2 >>| get_uint16
   let uint32 =
     take 4 >>| get_uint32
   let uint64 =
     take 8 >>| get_uint64
-  let int8 =
-    take 1 >>| get_int8
   let int16 =
     take 2 >>| get_int16
   let int32 =

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -727,24 +727,17 @@ module Make_endian(Es : EndianString.EndianStringSig) : I = struct
   let get_uint64 s = Es.get_int64 s 0
 
   (* int *)
-  let uint16 =
-    take 2 >>| get_uint16
-  let uint32 =
-    take 4 >>| get_uint32
-  let uint64 =
-    take 8 >>| get_uint64
-  let int16 =
-    take 2 >>| get_int16
-  let int32 =
-    take 4 >>| get_int32
-  let int64 =
-    take 8 >>| get_int64
+  let int16 = take 2 >>| get_int16
+  let int32 = take 4 >>| get_int32
+  let int64 = take 8 >>| get_int64
+
+  let uint16 = take 2 >>| get_uint16
+  let uint32 = take 4 >>| get_uint32
+  let uint64 = take 8 >>| get_uint64
 
   (* float *)
-  let float =
-    take 4 >>| get_float
-  let double =
-    take 8 >>| get_double
+  let float  = take 4 >>| get_float
+  let double = take 8 >>| get_double
 end
 
 module Le = Make_endian(EndianString.LittleEndian_unsafe)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -78,6 +78,12 @@ val not_char : char -> char t
 val any_char : char t
 (** [any_char] accepts any character and returns it. *)
 
+val any_uint8 : int t
+(** [any_uint8] accepts any byte and returns it as an unsigned int8. *)
+
+val any_int8 : int t
+(** [any_int8] accepts any byte and returns it as a signed int8. *)
+
 val satisfy : (char -> bool) -> char t
 (** [satisfy f] accepts any character for which [f] returns [true] and returns
     the accepted character. *)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -168,9 +168,6 @@ module Le : I
 module Be : I
 (** Big endian parsers *)
 
-module Ne : I
-(** Native endian parsers *)
-
 
 (** {2 Combinators} *)
 

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -140,14 +140,12 @@ val end_of_line : unit t
 
 module type I = sig
 
-  val int8 : int t
   val int16 : int t
   val int32 : int32 t
   val int64 : int64 t
   (** [intN] reads [N] bits and interprets them as a signed integers. The
       assumed endianness of the bits is determined by the implementation. *)
 
-  val uint8 : int t
   val uint16 : int t
   val uint32 : int32 t
   val uint64 : int64 t

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -147,16 +147,6 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     check : ?size:int -> msg:string -> 'a Angstrom.t -> string list -> 'a -> unit;
   }
 
-  let int8 = {
-    name = "int8";
-    size = 1;
-    zero = 0;
-    min = ~-128;
-    max = 127;
-    set = Es.set_int8;
-    get = Es.get_int8;
-    check = check_int;
-  }
   let int16 = {
     name = "int16";
     size = 2;
@@ -210,7 +200,6 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     check = check_float;
   }
 
-  let uint8 = { int8 with name = "uint8"; min = 0; max = 255 }
   let uint16 = { int16 with name = "uint16"; min = 0; max = 65535 }
   let uint32 = { int32 with name = "uint32" }
   let uint64 = { int64 with name = "uint64" }
@@ -230,11 +219,9 @@ module Endian(Es : EndianString.EndianStringSig) = struct
   module type EndianSig = module type of Le
 
   let tests (module E : EndianSig) = [
-    make_tests int8   E.int8;
     make_tests int16  E.int16;
     make_tests int32  E.int32;
     make_tests int64  E.int64;
-    make_tests uint8  E.uint8;
     make_tests uint16 E.uint16;
     make_tests uint32 E.uint32;
     make_tests uint64 E.uint64;

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -109,6 +109,12 @@ let basic_constructors =
       check_c    ~msg:"non-empty buffer" any_char ["a"] 'a';
       check_fail ~msg:"empty buffer"     any_char [""]
   end
+  ; "any_{,u}int8", `Quick, begin fun () ->
+    check_int ~msg:"positive sign preserved" any_int8 ["\127"] 127;
+    check_int ~msg:"negative sign preserved" any_int8 ["\129"] (-127);
+    check_int ~msg:"sign invariant" any_uint8 ["\127"] 127;
+    check_int ~msg:"sign invariant" any_uint8 ["\129"] (129)
+  end
   ; "string", `Quick, begin fun () ->
       check_s ~msg:"empty string, non-empty buffer" (string "")     ["asdf"] "";
       check_s ~msg:"empty string, empty buffer"     (string "")     [""]     "";

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -235,9 +235,6 @@ let little_endian =
 let big_endian =
   let module E = Endian(EndianString.BigEndian) in
   E.tests (module Be)
-let native_endian =
-  let module E = Endian(EndianString.NativeEndian) in
-  E.tests (module Ne)
 
 let monadic =
   [ "fail", `Quick, begin fun () ->
@@ -320,7 +317,6 @@ let () =
     [ "basic constructors"    , basic_constructors
     ; "little endian"         , little_endian
     ; "big endian"            , big_endian
-    ; "native endian"         , native_endian
     ; "monadic interface"     , monadic
     ; "applicative interface" , applicative
     ; "alternative"           , alternative


### PR DESCRIPTION
This pull request affects the endian parsers in the following way:

* `int8` and `uint8` have been dropped from the interface, since they are only one byte long and therefore byte order cannot affect how they're parsed; and
* the `Ne` native-endian module has been dropped, since using it may result in inconsistent parser behavior.