### PR TITLE
add at_end_of_input parser

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -456,18 +456,6 @@ let demand_input =
       prompt input pos fail' succ'
   }
 
-let want_input =
-  { run = fun input pos more _fail succ ->
-    if pos < Input.length input then
-      succ input pos more true
-    else if more = Complete then
-      succ input pos more false
-    else
-      let succ' input' pos' more' = succ input' pos' more' true
-      and fail' input' pos' more' = succ input' pos' more' false in
-      prompt input pos fail' succ'
-  }
-
 let ensure_suspended n input pos more fail succ =
   let rec go =
     { run = fun input' pos' more' fail' succ' ->
@@ -639,17 +627,6 @@ let take_while1 f =
 let take_till f =
   take_while (fun c -> not (f c))
 
-let take_rest =
-  let rec go acc =
-    want_input >>= function
-      | true  ->
-        available >>= fun n ->
-        unsafe_substring n >>= fun str ->
-        go (str::acc)
-      | false ->
-        return (List.rev acc)
-  in
-  go []
 
 let choice ps =
   List.fold_right (<|>) ps (fail "empty")

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -484,17 +484,23 @@ let ensure n =
 
 (** END: getting input *)
 
-let end_of_input =
-  { run = fun input pos more fail succ ->
+let at_end_of_input =
+  { run = fun input pos more _ succ ->
     if pos < Input.length input then
-      fail input pos more [] "end_of_input"
+      succ input pos more false
     else if more = Complete then
-      succ input pos more ()
+      succ input pos more true
     else
-      let succ' input' pos' more' = fail input' pos' more' [] "end_of_input"
-      and fail' input' pos' more' = succ input' pos' more' () in
+      let succ' input' pos' more' = succ input' pos' more' false
+      and fail' input' pos' more' = succ input' pos' more' true in
       prompt input pos fail' succ'
   }
+
+let end_of_input =
+  at_end_of_input
+  >>= function
+    | true  -> return ()
+    | false -> fail "end_of_input"
 
 let advance n =
   { run = fun input pos more _fail succ -> succ input (pos + n) more () }

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -129,6 +129,9 @@ val take_till : (char -> bool) -> string t
     This parser does not fail. If [f] returns [true] on the first character, it
     will return the empty string. *)
 
+val at_end_of_input : bool t
+(** [at_end_of_input] returns whether the end of the end of input has been
+    reached. This parser always succeeds. *)
 
 val end_of_input : unit t
 (** [end_of_input] succeeds if all the input has been consumed, and fails

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -129,9 +129,6 @@ val take_till : (char -> bool) -> string t
     This parser does not fail. If [f] returns [true] on the first character, it
     will return the empty string. *)
 
-val take_rest : string list t
-(** [take_rest] accepts the rest of the input and returns it as a list of
-    strings. *)
 
 val end_of_input : unit t
 (** [end_of_input] succeeds if all the input has been consumed, and fails
@@ -466,5 +463,4 @@ end
 (* These values are not part of the public API. *)
 
 val pos : int t
-val want_input : bool t
 val available : int t


### PR DESCRIPTION
This pull request makes two changes to the public API:

* It removes the `take_rest` parser, which would accept all remaining input, returning it in chunks to the user. This parser was a bad idea due to its memory characteristics: it required all remaining input to be in memory, all at once, which would be copied incrementally into chunks, and then finally returned. 

* It remove `want_input` from the "private API" section and introduces the related `at_end_of_input` parser. The two are related in that `at_end_of_input = want_input >>| not`.