### PR TITLE
endian: inline signatures, capitalize E

### DIFF
--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -42,8 +42,8 @@ let main () =
       match Angstrom.(parse_only (skip_many RFC2616.request) (`String http_get)) with
       | R.Ok _ -> ()
       | R.Error err -> failwith err);
-    make_endian "int64 le" Angstrom.Le.int64;
-    make_endian "int64 be" Angstrom.Be.int64;
+    make_endian "int64 le" Angstrom.LE.int64;
+    make_endian "int64 be" Angstrom.BE.int64;
   ])
 
 let () = main ()

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -691,20 +691,7 @@ let skip_many1 p =
 let end_of_line =
   (char '\n' *> return ()) <|> (string "\r\n" *> return ()) <?> "end_of_line"
 
-module type I = sig
-  val int16 : int t
-  val int32 : int32 t
-  val int64 : int64 t
-
-  val uint16 : int t
-  val uint32 : int32 t
-  val uint64 : int64 t
-
-  val float : float t
-  val double : float t
-end
-
-module Make_endian(Es : EndianString.EndianStringSig) : I = struct
+module Make_endian(Es : EndianString.EndianStringSig) = struct
   let get_float s = Es.get_float s 0
   let get_double s = Es.get_double s 0
 
@@ -730,5 +717,5 @@ module Make_endian(Es : EndianString.EndianStringSig) : I = struct
   let double = take 8 >>| get_double
 end
 
-module Le = Make_endian(EndianString.LittleEndian_unsafe)
-module Be = Make_endian(EndianString.BigEndian_unsafe)
+module BE = Make_endian(EndianString.BigEndian_unsafe)
+module LE = Make_endian(EndianString.LittleEndian_unsafe)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -146,37 +146,50 @@ val end_of_input : unit t
     otherwise. *)
 
 
-(** {2 Little/Big/Native endian parsers} *)
-
-module type I = sig
-
+(** Big endian parsers *)
+module BE : sig
   val int16 : int t
   val int32 : int32 t
   val int64 : int64 t
-  (** [intN] reads [N] bits and interprets them as a signed integers. The
-      assumed endianness of the bits is determined by the implementation. *)
+  (** [intN] reads [N] bits and interprets them as big endian signed integers. *)
 
   val uint16 : int t
   val uint32 : int32 t
   val uint64 : int64 t
-  (** [uintN] reads [N] bits and interprets them as an unsigned integers. The
-      assumed endianness of the bits is determined by the implementation. *)
+  (** [uintN] reads [N] bits and interprets them as big endian unsigned
+      integers. *)
 
   val float : float t
-  (** [float] reads four bytes and interprets them as a floating point value.
-      The assumed endianness of the bits is determined by the implementation. *)
+  (** [float] reads 32 bits and interprets them as a big endian floating
+      point value. *)
 
   val double : float t
-  (** [double] reads eight bytes and interprets them as a floating point value.
-      The assumed endianness of the bits is determined by the implementation. *)
-
+  (** [double] reads 64 bits and interprets them as a big endian floating
+      point value. *)
 end
 
-module Le : I
 (** Little endian parsers *)
+module LE : sig
+  val int16 : int t
+  val int32 : int32 t
+  val int64 : int64 t
+  (** [intN] reads [N] bits and interprets them as little endian signed
+      integers. *)
 
-module Be : I
-(** Big endian parsers *)
+  val uint16 : int t
+  val uint32 : int32 t
+  val uint64 : int64 t
+  (** [uintN] reads [N] bits and interprets them as little endian unsigned
+      integers. *)
+
+  val float : float t
+  (** [float] reads 32 bits and interprets them as a little endian floating
+      point value. *)
+
+  val double : float t
+  (** [double] reads 64 bits and interprets them as a little endian floating
+      point value. *)
+end
 
 
 (** {2 Combinators} *)

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -216,7 +216,7 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     check_ok ~msg:"trailing" e.testable parse [dump e e.zero ^ "\xff"] e.zero;
   end
 
-  module type EndianSig = module type of Le
+  module type EndianSig = module type of LE
 
   let tests (module E : EndianSig) = [
     make_tests int16  E.int16;
@@ -231,10 +231,10 @@ module Endian(Es : EndianString.EndianStringSig) = struct
 end
 let little_endian =
   let module E = Endian(EndianString.LittleEndian) in
-  E.tests (module Le)
+  E.tests (module LE)
 let big_endian =
   let module E = Endian(EndianString.BigEndian) in
-  E.tests (module Be)
+  E.tests (module BE)
 
 let monadic =
   [ "fail", `Quick, begin fun () ->


### PR DESCRIPTION
This pull request goes back to the original signature setup for the big endian and little endian parser modules, while also capitalizing the 'e' in the module names; `Le` is now `LE` and `Be` is now `BE`.

Playing feature ping-pong with #50. :(