### PR TITLE
Make Angstrom.t covariant

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -209,7 +209,7 @@ module Unbuffered = struct
   let fail_k    buf pos _ marks msg = Fail(marks, msg)
   let succeed_k buf pos _       v   = Done(v, pos - Input.initial_commit_pos buf)
 
-  type 'a t =
+  type +'a t =
     { run : 'r. ('r failure -> ('a, 'r) success -> 'r state) with_input }
 
   let fail_to_string marks err =

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -44,7 +44,7 @@
     reusable parsers suitable for high-performance applications. *)
 
 
-type 'a t
+type +'a t
 (** A parser for values of type ['a]. *)
 
 


### PR DESCRIPTION
As discussed in #61, this PR adds a variance annotation to `'a Angstrom.t`, such that is is covariant in `'a`. This makes `Angstrom.t` play well with polymorphic variants.

Example:

```ocaml
let x : [`Foo] Angstrom.t  = Angstrom.return `Foo;;
let y = (x :> [`Foo | `Bar] Angstrom.t);;
```

Previously the example above would be rejected with the error ```Type [ `Foo ] Angstrom.t is not a subtype of [ `Bar | `Foo ] Angstrom.t```.

I haven't added any tests -- let me know if you'd like that.