### PR TITLE
positions: consistently return success and failure position

### DIFF
--- a/async/angstrom_async.ml
+++ b/async/angstrom_async.ml
@@ -53,7 +53,7 @@ let rec finalize state result =
 
 let response = function
   | Partial p  -> `Consumed(p.committed, `Need_unknown)
-  | Done(_, c) -> `Stop_consumed((), c)
+  | Done(c, _) -> `Stop_consumed((), c)
   | Fail _     -> `Stop ()
 
 let default_pushback () = Deferred.unit

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -388,8 +388,8 @@ module Buffered : sig
 
   type 'a state =
     | Partial of ([ input | `Eof ] -> 'a state) (** The parser requires more input. *)
-    | Done    of 'a * unconsumed (** The parser succeeded. *)
-    | Fail    of string list * string * unconsumed (** The parser failed. *)
+    | Done    of unconsumed * 'a (** The parser succeeded. *)
+    | Fail    of unconsumed * string list * string (** The parser failed. *)
 
   val parse : ?initial_buffer_size:int -> ?input:input -> 'a t -> 'a state
   (** [parse ?initial_buffer_size ?input t] runs [t] on [input], if present,
@@ -448,8 +448,8 @@ module Unbuffered : sig
 
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
-    | Done    of 'a * int (** The parser succeeded, consuming specified bytes. *)
-    | Fail    of string list * string (** The parser failed. *)
+    | Done    of int * 'a (** The parser succeeded, consuming specified bytes. *)
+    | Fail    of int * string list * string (** The parser failed, consuming specified bytes. *)
   and 'a partial =
     { committed : int
       (** The number of bytes committed during the last input feeding.


### PR DESCRIPTION
The Fail state for the Unbuffered interface previously did not return
indicate where in the input the parse failed. While this is not the most
useful information for parsers that make use of extensive backtracking,
it can help in some cases.

As part of the change, move the position information for both the
Buffered and Unbuffered state types to be the first value contained in
the variant.

Addresses #69