### PR TITLE
uint ops

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -727,7 +727,6 @@ module Make_endian(Es : EndianString.EndianStringSig) = struct
 
   let get_uint16 s = Es.get_uint16 s 0
   let get_uint32 s = Es.get_int32 s 0
-  let get_uint64 s = Es.get_int64 s 0
 
   (* int *)
   let int16 = take 2 >>| get_int16
@@ -736,7 +735,6 @@ module Make_endian(Es : EndianString.EndianStringSig) = struct
 
   let uint16 = take 2 >>| get_uint16
   let uint32 = take 4 >>| get_uint32
-  let uint64 = take 8 >>| get_uint64
 
   (* float *)
   let float  = take 4 >>| get_float

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -721,20 +721,16 @@ module Make_endian(Es : EndianString.EndianStringSig) = struct
   let get_float s = Es.get_float s 0
   let get_double s = Es.get_double s 0
 
-  let get_int16 s = Es.get_int16 s 0
-  let get_int32 s = Es.get_int32 s 0
-  let get_int64 s = Es.get_int64 s 0
-
+  let get_int16  s = Es.get_int16 s 0
   let get_uint16 s = Es.get_uint16 s 0
-  let get_uint32 s = Es.get_int32 s 0
+  let get_int32  s = Es.get_int32 s 0
+  let get_int64  s = Es.get_int64 s 0
 
   (* int *)
-  let int16 = take 2 >>| get_int16
-  let int32 = take 4 >>| get_int32
-  let int64 = take 8 >>| get_int64
-
+  let int16  = take 2 >>| get_int16
   let uint16 = take 2 >>| get_uint16
-  let uint32 = take 4 >>| get_uint32
+  let int32  = take 4 >>| get_int32
+  let int64  = take 8 >>| get_int64
 
   (* float *)
   let float  = take 4 >>| get_float

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -166,7 +166,6 @@ module BE : sig
 
   val uint16 : int t
   val uint32 : int32 t
-  val uint64 : int64 t
   (** [uintN] reads [N] bits and interprets them as big endian unsigned
       integers. *)
 
@@ -189,7 +188,6 @@ module LE : sig
 
   val uint16 : int t
   val uint32 : int32 t
-  val uint64 : int64 t
   (** [uintN] reads [N] bits and interprets them as little endian unsigned
       integers. *)
 

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -165,9 +165,8 @@ module BE : sig
   (** [intN] reads [N] bits and interprets them as big endian signed integers. *)
 
   val uint16 : int t
-  val uint32 : int32 t
-  (** [uintN] reads [N] bits and interprets them as big endian unsigned
-      integers. *)
+  (** [uint16] reads [16] bits and interprets them as a big endian unsigned
+      integer. *)
 
   val float : float t
   (** [float] reads 32 bits and interprets them as a big endian floating
@@ -187,9 +186,8 @@ module LE : sig
       integers. *)
 
   val uint16 : int t
-  val uint32 : int32 t
-  (** [uintN] reads [N] bits and interprets them as little endian unsigned
-      integers. *)
+  (** [uint16] reads [16] bits and interprets them as a little endian unsigned
+      integer. *)
 
   val float : float t
   (** [float] reads 32 bits and interprets them as a little endian floating

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -202,7 +202,6 @@ module Endian(Es : EndianString.EndianStringSig) = struct
 
   let uint16 = { int16 with name = "uint16"; min = 0; max = 65535 }
   let uint32 = { int32 with name = "uint32" }
-  let uint64 = { int64 with name = "uint64" }
 
    let dump e x =
      let buf = Bytes.create e.size in
@@ -224,7 +223,6 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     make_tests int64  E.int64;
     make_tests uint16 E.uint16;
     make_tests uint32 E.uint32;
-    make_tests uint64 E.uint64;
     make_tests float  E.float;
     make_tests double E.double;
   ]

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -222,7 +222,6 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     make_tests int32  E.int32;
     make_tests int64  E.int64;
     make_tests uint16 E.uint16;
-    make_tests uint32 E.uint32;
     make_tests float  E.float;
     make_tests double E.double;
   ]


### PR DESCRIPTION
Remove unsigned integer parsers that are redundant with their signed counterparts.