### PR TITLE
Update to use and support the latest Alcotest

### DIFF
--- a/angstrom.opam
+++ b/angstrom.opam
@@ -14,7 +14,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "alcotest" {test & >= "0.6.0" & < "0.8.0"}
+  "alcotest" {test & >= "0.8.1"}
   "cstruct" {>= "0.7.0"}
   "ocplib-endian" {>= "0.6"}
   "result"

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -187,7 +187,7 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     min = ~-.2e10;
     max = 2e10;
     dump = Es.set_float;
-    testable = Alcotest.float
+    testable = Alcotest.float 0.0
   }
   let double = {
     name = "double";
@@ -197,7 +197,7 @@ module Endian(Es : EndianString.EndianStringSig) = struct
     min = ~-.2e30;
     max = 2e30;
     dump = Es.set_double;
-    testable = Alcotest.float
+    testable = Alcotest.float 0.0
   }
 
   let uint16 = { int16 with name = "uint16"; min = 0; max = 65535 }


### PR DESCRIPTION
A epsilon parameter was added to Alcotest.float.  Using 0.0 seems
appropriate here as we're testing for precise equality.

The opam constraint is set to 0.8.1 as 0.8.0 didn't properly support an epsilon of 0.0.