### PR TITLE
fix-chainl1: fix implementation of chainl1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ let div = char '/' *> return (/)
 let integer =
   take_while1 (function '0' .. '9' -> true | _ -> false) >>| int_of_string
 
-
 let chainl1 e op =
   let rec go acc =
     (lift2 (fun f x -> f acc x) op e >>= go) <|> return acc in

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ let div = char '/' *> return (/)
 let integer =
   take_while1 (function '0' .. '9' -> true | _ -> false) >>| int_of_string
 
+
 let chainl1 e op =
-  fix (fun r ->
-    e >>= fun x -> (op <*> (return x) <*> r) <|> return x)
+  let rec go acc =
+    (lift2 (fun f x -> f acc x) op e >>= go) <|> return acc in
+  e >>= fun init -> go init
 
 let expr : int t =
   fix (fun expr ->


### PR DESCRIPTION
The previous implementation was for `chainr1`.

Closes #90