### PR TITLE
move-bigstring: collect Bigstring operations into internal module

### DIFF
--- a/lib/bigstring.ml
+++ b/lib/bigstring.ml
@@ -1,0 +1,42 @@
+type bigstring =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+type t = bigstring
+
+let create size = Bigarray.(Array1.create char c_layout size)
+let empty       = create 0
+
+module BA1 = Bigarray.Array1
+
+let length t = BA1.dim t
+let unsafe_get = BA1.unsafe_get
+let unsafe_set = BA1.unsafe_set
+
+let blit src src_off dst dst_off len =
+  BA1.(blit (sub src src_off len) (sub dst dst_off len))
+
+let blit_from_string src src_off dst dst_off len =
+  for i = 0 to len - 1 do
+    BA1.unsafe_set dst (dst_off + i) (String.unsafe_get src (src_off + i))
+  done
+
+let blit_from_bytes src src_off dst dst_off len =
+  blit_from_string (Bytes.unsafe_to_string src) src_off dst dst_off len
+
+let blit_to_bytes src src_off dst dst_off len =
+  for i = 0 to len - 1 do
+    Bytes.unsafe_set dst (dst_off +i) (BA1.unsafe_get src (src_off + i))
+  done
+
+let sub t ~off ~len =
+  BA1.sub t off len
+
+let substring t ~off ~len =
+  let b = Bytes.create len in
+  blit_to_bytes t off b 0 len;
+  Bytes.unsafe_to_string b
+
+let of_string ~off ~len s =
+  let b = create len in
+  blit_from_string s off b 0 len;
+  b

--- a/lib/bigstring.mli
+++ b/lib/bigstring.mli
@@ -1,0 +1,28 @@
+(** {1 Bigstrings}
+
+    This module is not part of Angstrom's public API to as not not cause
+    confusion, usability issues, and linking errors related to naming conflicts
+    with other existing libraries.
+
+    All of these operations skip bounds checks when possible. *)
+
+type t =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+val create : int -> t
+val empty  : t
+
+val of_string : off:int -> len:int -> string -> t
+
+val length : t -> int
+val unsafe_get : t -> int -> char
+val unsafe_set : t -> int -> char -> unit
+
+val blit             : t       -> int -> t -> int -> int -> unit
+val blit_from_string : string  -> int -> t -> int -> int -> unit
+val blit_from_bytes  : Bytes.t -> int -> t -> int -> int -> unit
+
+val blit_to_bytes  : t -> int -> Bytes.t -> int -> int -> unit
+
+val sub : t -> off:int -> len:int -> t
+val substring : t -> off:int -> len:int -> string

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,5 +3,4 @@
 (library
  ((name angstrom)
   (public_name angstrom)
-  (wrapped false)
   (libraries (cstruct ocplib-endian result))))


### PR DESCRIPTION
In order to improve code organization, move Bigstring operations into an internal module. This will not be exposed in the public API.