### PR TITLE
remove-cstruct: remove the dependency on cstruct

### DIFF
--- a/angstrom.opam
+++ b/angstrom.opam
@@ -15,7 +15,7 @@ build-test: [
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "alcotest" {test & >= "0.8.1"}
-  "cstruct" {>= "0.7.0"}
+  "base-bigarray"
   "ocplib-endian" {>= "0.6"}
   "result"
 ]

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -389,7 +389,7 @@ val parse_only : 'a t -> input -> ('a, string) Result.result
     in can also be reused. *)
 module Buffered : sig
   type unconsumed =
-    { buffer : bigstring
+    { buf : bigstring
     ; off : int
     ; len : int }
 

--- a/lib/buffering.ml
+++ b/lib/buffering.ml
@@ -1,0 +1,91 @@
+type t =
+  { mutable buf : Bigstring.t
+  ; mutable off : int
+  ; mutable len : int }
+
+let of_bigstring ~off ~len buf =
+  assert (off >= 0);
+  assert (Bigstring.length buf >= len - off);
+  { buf; off; len }
+
+let create len =
+  of_bigstring ~off:0 ~len:0 (Bigstring.create len)
+
+let writable_space t =
+  Bigstring.length t.buf - t.len
+
+let trailing_space t =
+  Bigstring.length t.buf - (t.off + t.len)
+
+let compress t =
+  Bigstring.blit t.buf t.off t.buf 0 t.len;
+  t.off <- 0
+
+let grow t to_copy =
+  let old_len = Bigstring.length t.buf in
+  let new_len = ref old_len in
+  let space = writable_space t in
+  while space + !new_len - old_len < to_copy do
+    new_len := (3 * !new_len) / 2
+  done;
+  let new_buf = Bigstring.create !new_len in
+  Bigstring.blit t.buf t.off new_buf 0 t.len;
+  t.buf <- new_buf;
+  t.off <- 0
+
+let ensure t to_copy =
+  if trailing_space t < to_copy then
+    if writable_space t >= to_copy
+    then compress t
+    else grow t to_copy
+
+let write_pos t =
+  t.off + t.len
+
+let read_pos t =
+  t.off
+
+let feed_string t ~off ~len str =
+  assert (off >= 0);
+  assert (String.length str >= len - off);
+  ensure t len;
+  Bigstring.blit_from_string str off t.buf (write_pos t) len;
+  t.len <- t.len + len
+
+let feed_bigstring t ~off ~len b =
+  assert (off >= 0);
+  assert (Bigstring.length b >= len - off);
+  ensure t len;
+  Bigstring.blit b off t.buf (write_pos t) len;
+  t.len <- t.len + len
+
+let feed_input t = function
+  | `String    s -> feed_string    t ~off:0 ~len:(String   .length s) s
+  | `Bigstring b -> feed_bigstring t ~off:0 ~len:(Bigstring.length b) b
+
+let shift t n =
+  assert (t.len >= n);
+  t.off <- t.off + n;
+  t.len <- t.len - n
+
+let for_reading { buf; off; len } =
+  Bigstring.sub ~off ~len buf
+
+module Unconsumed = struct
+  type t =
+    { buf : Bigstring.t
+    ; off : int
+    ; len : int }
+end
+
+let unconsumed ?(shift=0) { buf; off; len } =
+  assert (len >= shift);
+  { Unconsumed.buf; off = off + shift; len = len - shift }
+
+let of_unconsumed { Unconsumed.buf; off; len } =
+  { buf; off; len }
+
+type unconsumed = Unconsumed.t =
+  { buf : Bigstring.t
+  ; off : int
+  ; len : int }

--- a/lib/buffering.mli
+++ b/lib/buffering.mli
@@ -1,0 +1,20 @@
+type t
+
+val create : int -> t
+val of_bigstring : off:int -> len:int -> Bigstring.t -> t
+
+val feed_string    : t -> off:int -> len:int -> string -> unit
+val feed_bigstring : t -> off:int -> len:int -> Bigstring.t -> unit
+val feed_input : t -> [ `String of string | `Bigstring of Bigstring.t ] -> unit
+
+val shift : t -> int -> unit
+
+val for_reading : t -> Bigstring.t
+
+type unconsumed =
+  { buf : Bigstring.t
+  ; off : int
+  ; len : int }
+
+val unconsumed    : ?shift:int -> t -> unconsumed
+val of_unconsumed : unconsumed -> t

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,4 +3,4 @@
 (library
  ((name angstrom)
   (public_name angstrom)
-  (libraries (cstruct ocplib-endian result))))
+  (libraries (bigarray ocplib-endian result))))


### PR DESCRIPTION
This was just used for the buffered interface. Specifically for access to the `memcpy` C stubs. However, this interface is not performance-sensitive, so just drop the dependency, and allocate a bit
less along the way.