### PR TITLE
Fix performance regression

### DIFF
--- a/lib/bigstring.ml
+++ b/lib/bigstring.ml
@@ -12,9 +12,14 @@ let length t = BA1.dim t
 let unsafe_get = BA1.unsafe_get
 let unsafe_set = BA1.unsafe_set
 
-external blit            : t       -> int -> t       -> int -> int -> unit = "it_bigstring_blit_to_bigstring" [@@noalloc]
-external blit_to_bytes   : t       -> int -> Bytes.t -> int -> int -> unit = "it_bigstring_blit_to_bytes"     [@@noalloc]
-external blit_from_bytes : Bytes.t -> int -> t       -> int -> int -> unit = "it_bigstring_blit_from_bytes"   [@@noalloc]
+external blit            : t       -> int -> t       -> int -> int -> unit =
+  "angstrom_bigstring_blit_to_bigstring" [@@noalloc]
+
+external blit_to_bytes   : t       -> int -> Bytes.t -> int -> int -> unit =
+  "angstrom_bigstring_blit_to_bytes"     [@@noalloc]
+
+external blit_from_bytes : Bytes.t -> int -> t       -> int -> int -> unit =
+  "angstrom_bigstring_blit_from_bytes"   [@@noalloc]
 
 let blit_from_string src src_off dst dst_off len =
   blit_from_bytes (Bytes.unsafe_of_string src) src_off dst dst_off len

--- a/lib/bigstring.ml
+++ b/lib/bigstring.ml
@@ -12,21 +12,12 @@ let length t = BA1.dim t
 let unsafe_get = BA1.unsafe_get
 let unsafe_set = BA1.unsafe_set
 
-let blit src src_off dst dst_off len =
-  BA1.(blit (sub src src_off len) (sub dst dst_off len))
+external blit            : t       -> int -> t       -> int -> int -> unit = "it_bigstring_blit_to_bigstring" [@@noalloc]
+external blit_to_bytes   : t       -> int -> Bytes.t -> int -> int -> unit = "it_bigstring_blit_to_bytes"     [@@noalloc]
+external blit_from_bytes : Bytes.t -> int -> t       -> int -> int -> unit = "it_bigstring_blit_from_bytes"   [@@noalloc]
 
 let blit_from_string src src_off dst dst_off len =
-  for i = 0 to len - 1 do
-    BA1.unsafe_set dst (dst_off + i) (String.unsafe_get src (src_off + i))
-  done
-
-let blit_from_bytes src src_off dst dst_off len =
-  blit_from_string (Bytes.unsafe_to_string src) src_off dst dst_off len
-
-let blit_to_bytes src src_off dst dst_off len =
-  for i = 0 to len - 1 do
-    Bytes.unsafe_set dst (dst_off +i) (BA1.unsafe_get src (src_off + i))
-  done
+  blit_from_bytes (Bytes.unsafe_of_string src) src_off dst dst_off len
 
 let sub t ~off ~len =
   BA1.sub t off len

--- a/lib/bigstring_stubs.c
+++ b/lib/bigstring_stubs.c
@@ -36,7 +36,7 @@
 #include <caml/bigarray.h>
 
 void
-it_bigstring_blit_to_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+angstrom_bigstring_blit_to_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((void *)Caml_ba_data_val(vsrc)) + Int_val(vsrc_off),
          *dst = ((void *)String_val(vdst))       + Int_val(vdst_off);
@@ -45,7 +45,7 @@ it_bigstring_blit_to_bytes(value vsrc, value vsrc_off, value vdst, value vdst_of
 }
 
 void
-it_bigstring_blit_to_bigstring(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+angstrom_bigstring_blit_to_bigstring(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((void *)Caml_ba_data_val(vsrc)) + Int_val(vsrc_off),
          *dst = ((void *)Caml_ba_data_val(vdst)) + Int_val(vdst_off);
@@ -54,7 +54,7 @@ it_bigstring_blit_to_bigstring(value vsrc, value vsrc_off, value vdst, value vds
 }
 
 void
-it_bigstring_blit_from_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+angstrom_bigstring_blit_from_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
 {
     void *src = ((void *)String_val(vsrc))       + Int_val(vsrc_off),
          *dst = ((void *)Caml_ba_data_val(vdst)) + Int_val(vdst_off);

--- a/lib/bigstring_stubs.c
+++ b/lib/bigstring_stubs.c
@@ -1,0 +1,63 @@
+/*----------------------------------------------------------------------------
+    Copyright (c) 2017 Inhabited Type LLC.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*/
+
+#include <string.h>
+#include <caml/mlvalues.h>
+#include <caml/bigarray.h>
+
+void
+it_bigstring_blit_to_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+{
+    void *src = ((void *)Caml_ba_data_val(vsrc)) + Int_val(vsrc_off),
+         *dst = ((void *)String_val(vdst))       + Int_val(vdst_off);
+    size_t len = Int_val(vlen);
+    memcpy(dst, src, len);
+}
+
+void
+it_bigstring_blit_to_bigstring(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+{
+    void *src = ((void *)Caml_ba_data_val(vsrc)) + Int_val(vsrc_off),
+         *dst = ((void *)Caml_ba_data_val(vdst)) + Int_val(vdst_off);
+    size_t len = Int_val(vlen);
+    memcpy(dst, src, len);
+}
+
+void
+it_bigstring_blit_from_bytes(value vsrc, value vsrc_off, value vdst, value vdst_off, value vlen)
+{
+    void *src = ((void *)String_val(vsrc))       + Int_val(vsrc_off),
+         *dst = ((void *)Caml_ba_data_val(vdst)) + Int_val(vdst_off);
+    size_t len = Int_val(vlen);
+    memcpy(dst, src, len);
+}

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,10 +1,13 @@
 (jbuild_version 1)
 
 (library
- ((name angstrom)
+ ((name        angstrom)
   (public_name angstrom)
   (libraries
     (bigarray
      result))
-  (c_names
-    (bigstring_stubs))))
+  (c_names (bigstring_stubs))
+  (js_of_ocaml (
+    (javascript_files (runtime.js))
+    ))
+  ))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,4 +3,8 @@
 (library
  ((name angstrom)
   (public_name angstrom)
-  (libraries (bigarray result))))
+  (libraries
+    (bigarray
+     result))
+  (c_names
+    (bigstring_stubs))))

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -31,19 +31,19 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*/
 
-function it_bigstring_blit_to_bytes(src, src_off, dst, dst_off, len) {
+function angstrom_bigstring_blit_to_bytes(src, src_off, dst, dst_off, len) {
   for (var i = 0; i < len; i++) {
     string_unsafe_set(dst, dst_off + i, caml_ba_unsafe_ref_1(src, src_off + i));
   }
 }
 
-function it_bigstring_blit_to_bigstring(src, src_off, dst, dst_off, len) {
+function angstrom_bigstring_blit_to_bigstring(src, src_off, dst, dst_off, len) {
   for (var i = 0; i < len; i++) {
     caml_ba_unsafe_set_1(dst, dst_off + i, caml_ba_unsafe_ref_1(src, src_off + i));
   }
 }
 
-function it_bigstring_blit_from_bytes(src, src_off, dst, dst_off, len) {
+function angstrom_bigstring_blit_from_bytes(src, src_off, dst, dst_off, len) {
   for (var i = 0; i < len; i++) {
     caml_ba_unsafe_set_1(dst, dstoff + i, string_unsafe_get(src, src_off + i));
   }

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,0 +1,50 @@
+/*----------------------------------------------------------------------------
+    Copyright (c) 2017 Inhabited Type LLC.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*/
+
+function it_bigstring_blit_to_bytes(src, src_off, dst, dst_off, len) {
+  for (var i = 0; i < len; i++) {
+    string_unsafe_set(dst, dst_off + i, caml_ba_unsafe_ref_1(src, src_off + i));
+  }
+}
+
+function it_bigstring_blit_to_bigstring(src, src_off, dst, dst_off, len) {
+  for (var i = 0; i < len; i++) {
+    caml_ba_unsafe_set_1(dst, dst_off + i, caml_ba_unsafe_ref_1(src, src_off + i));
+  }
+}
+
+function it_bigstring_blit_from_bytes(src, src_off, dst, dst_off, len) {
+  for (var i = 0; i < len; i++) {
+    caml_ba_unsafe_set_1(dst, dstoff + i, string_unsafe_get(src, src_off + i));
+  }
+}


### PR DESCRIPTION
In the latest move away from cstructs, the library lost access to a `memcpy` based blit operation, which slowed down the HTTP  by a bit. Here's the regression at the parent of this PR:

```
┌──────────┬─────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name     │    Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼─────────────┼────────────┼──────────┼──────────┼────────────┤
│ http     │ 57_108.98us │ 7_626.20kw │  52.65kw │  52.65kw │    100.00% │
└──────────┴─────────────┴────────────┴──────────┴──────────┴────────────┘
```

and here are the benchmarks at the tip of this PR:

```
┌──────────┬─────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name     │    Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────┼─────────────┼────────────┼──────────┼──────────┼────────────┤
│ http     │ 35_019.03us │ 7_626.20kw │  52.65kw │  52.65kw │    100.00% │
└──────────┴─────────────┴────────────┴──────────┴──────────┴────────────┘
```
