### PR TITLE
Fixed the peek_char combinator

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -358,7 +358,7 @@ let rec prompt input pos fail succ =
     if length < uncommitted_bytes then
       failwith "prompt: input shrunk!";
     let input = Input.create commit_pos input in
-    if length = uncommitted_bytes then
+    if length = uncommitted_bytes || pos = Input.length input then
       if more = Complete then
         fail input pos Complete
       else
@@ -462,12 +462,8 @@ let peek_char =
     else if more = Complete then
       succ input pos more None
     else
-      let rec succ' input' pos' more' =
-        if pos' < Input.length input' then
-          succ input' pos' more' (Some (Input.get_char input' pos'))
-        else if more' = Complete then
-          succ input' pos' more' None
-        else prompt input' pos' fail' succ'
+      let succ' input' pos' more' =
+        succ input' pos' more' (Some (Input.get_char input' pos'))
       and fail' input' pos' more' =
         succ input' pos' more' None in
       prompt input pos fail' succ'

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -463,7 +463,7 @@ let peek_char =
       succ input pos more None
     else
       let rec succ' input' pos' more' =
-        if pos < Input.length input then
+        if pos' < Input.length input' then
           succ input' pos' more' (Some (Input.get_char input' pos'))
         else if more' = Complete then
           succ input' pos' more' None

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -462,8 +462,12 @@ let peek_char =
     else if more = Complete then
       succ input pos more None
     else
-      let succ' input' pos' more' =
-        succ input' pos' more' (Some (Input.get_char input' pos'))
+      let rec succ' input' pos' more' =
+        if pos < Input.length input then
+          succ input' pos' more' (Some (Input.get_char input' pos'))
+        else if more' = Complete then
+          succ input' pos' more' None
+        else prompt input' pos' fail' succ'
       and fail' input' pos' more' =
         succ input' pos' more' None in
       prompt input pos fail' succ'

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -338,6 +338,26 @@ let incremental =
         (string "thisthat") ["this"; "that"] "thisthat";
       check_s ~msg:"string straddling 3 inputs"
         (string "thisthat") ["thi"; "st"; "hat"] "thisthat";
+      end
+  ; "peek_char and empty chunks", `Quick, begin fun () ->
+      let decoder len =
+        let open Angstrom in
+
+        let buf = Buffer.create len in
+
+        fix @@ fun m ->
+        available >>= function
+        | 0 -> peek_char >>= (function
+            | Some _ -> commit *> m
+            | None ->
+              let ret = Buffer.contents buf in
+              Buffer.clear buf;
+              commit *> return ret)
+        | n -> take n >>= fun chunk -> Buffer.add_string buf chunk; commit *> m
+      in
+
+      check_s ~msg:"empty input multiple times and peek_char"
+        (decoder 0xFF) [ "Whole Lotta Love"; ""; ""; "" ] "Whole Lotta Love"
     end
   ; "across chunk boundary", `Quick, begin fun () ->
       check_s ~size:4 ~msg:"string on each side of 2 chunks"


### PR DESCRIPTION
In my mind, `peek_char` could never fail. In my implementation of `ocaml-git`, I need at a specific point to load directly all of the input in a `Buffer.t`:

```ocaml
  let decoder len =
      let buf = Buffer.create len in
      let open Angstrom in

      fix @@ fun m ->
      available >>= function
      | 0 ->
        peek_char
        >>= (function
            | Some _ -> commit *> m
            | None ->
              let cs = Cstruct.of_string (Buffer.contents buf) in
              Buffer.clear buf;
              return cs <* commit)
      | n -> take n >>= fun chunk ->
        Buffer.add_string buf chunk;
        commit *> m
```

This is a __non-optimized__ way to load all of the input in a `Buffer.t` and return at the end a `Cstruct.t`.

The problem concern the combinator `peek_char`. Indeed, when we consume all of the current `input`, we call `peek_char` to call indirectly `prompt` and ask to the user to refill the input. However, an empty input with the `Complete` tag could happen (when the sys-call `read` in the hood returns `0`).

At this stage, we are in the `succ'` function inside the `peek_char` combinator which one considers than the `input'` has at least one character (and does not do any verification about that). As I said, when the user refill the input by an empty `bigarray`, `peek_char` raises a non-expected (according to the documentation) exception (`Index out of bounds`).

This PR add the verification needed in `peek_char` for this specific case. I did not do a benchmark of this change. An other task could be a fastest combinator to only load the flow in a `Buffer.t`/`Cstruct.t` - but it's not the purpose of this PR.