### PR TITLE
fix-angstrom-async-contraints: require angstrom >= 0.7.0

### DIFF
--- a/angstrom-async.opam
+++ b/angstrom-async.opam
@@ -15,7 +15,7 @@ build-test: [
 ]
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
-  "angstrom" {>= "0.6.0"}
+  "angstrom" {>= "0.7.0"}
   "async"    {>= "v0.9.0"}
 ]
 available: [ ocaml-version >= "4.03.0" ]


### PR DESCRIPTION
Pointed out by @andreas in ocaml/opam-repository#10286.