### PR TITLE
bigstring-intrinsics: use them

### DIFF
--- a/lib/bigstring.ml
+++ b/lib/bigstring.ml
@@ -9,8 +9,8 @@ let empty       = create 0
 module BA1 = Bigarray.Array1
 
 let length t = BA1.dim t
-let unsafe_get = BA1.unsafe_get
-let unsafe_set = BA1.unsafe_set
+external unsafe_get : t -> int -> char         = "%caml_ba_unsafe_ref_1"
+external unsafe_set : t -> int -> char -> unit = "%caml_ba_unsafe_set_1"
 
 external blit            : t       -> int -> t       -> int -> int -> unit =
   "angstrom_bigstring_blit_to_bigstring" [@@noalloc]


### PR DESCRIPTION
Prior to this commit, `caml_ba_get_N` was at the top of the perf report for the json benchmark. Using intrinsics, those have disappeared from the report and performance has improved.

Before:
```
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼────────────┤
│ twitter1    │     26.07us │     7.56kw │      10.07w │      10.07w │      0.14% │
│ twitter10   │    184.28us │    46.83kw │     270.51w │     270.51w │      0.99% │
│ twitter20   │    349.57us │    92.65kw │   1_009.03w │   1_009.03w │      1.88% │
│ twitter-big │ 18_546.65us │ 3_697.06kw │ 190_906.45w │ 190_906.45w │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴────────────┘
```

After:
```
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼────────────┤
│ twitter1    │     16.50us │     7.56kw │      10.13w │      10.13w │      0.14% │
│ twitter10   │    115.12us │    46.83kw │     270.40w │     270.40w │      0.96% │
│ twitter20   │    227.68us │    92.65kw │   1_007.14w │   1_007.14w │      1.89% │
│ twitter-big │ 12_047.94us │ 3_697.05kw │ 191_139.09w │ 191_139.09w │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴────────────┘
```