### PR TITLE
 json-advance: the best way to skip over a char is advance 1

### DIFF
--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -79,6 +79,7 @@ let main () =
       make_bench "any_char"       any_char       contents;
       make_bench "char"           (char 'a')     contents;
       make_bench "not_char"       (not_char 'b') contents;
+      make_bench "advance 1"      (advance 1)    contents;
     ]
   in
   Command.run

--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -25,6 +25,7 @@ let make_bench name parser contents =
     match Angstrom.(parse_bigstring parser contents) with
     | R.Ok _ -> ()
     | R.Error err -> failwith err)
+;;
 
 let make_endian name p        = make_bench name (Angstrom.skip_many p)   zero
 let make_json   name contents = make_bench name RFC7159.json             contents
@@ -70,12 +71,23 @@ let main () =
         float_of_string "172429151501664");
     ]
   in
+  let characters =
+    let contents = Bigstring.of_string "a" in
+    let open Angstrom in
+    Bench.make_command [
+      make_bench "peek_char_fail" peek_char_fail contents;
+      make_bench "any_char"       any_char       contents;
+      make_bench "char"           (char 'a')     contents;
+      make_bench "not_char"       (not_char 'b') contents;
+    ]
+  in
   Command.run
     (Command.group ~summary:"various angstrom benchmarks" 
-      [ "json"   , json
-      ; "endian" , endian
-      ; "http"   , http 
-      ; "numbers", numbers
+      [ "json"      , json
+      ; "endian"    , endian
+      ; "http"      , http
+      ; "numbers"   , numbers
+      ; "characters", characters
     ])
 
 let () = main ()

--- a/examples/rFC7159.ml
+++ b/examples/rFC7159.ml
@@ -149,14 +149,15 @@ module S = struct
 end
 
 let json =
+  let advance1 = advance 1 in
   let pair x y = (x, y) in
   let buf = Buffer.create 0x1000 in
   let str = S.str buf in
   fix (fun json ->
     let mem = lift2 pair (quo *> str <* ns) json in
-    let obj = any_char *> sep_by vs mem  <* rcb >>| fun ms -> `Object ms in
-    let arr = any_char *> sep_by vs json <* rsb >>| fun vs -> `Array  vs in
-    let str = any_char *> str >>| fun s -> `String s in
+    let obj = advance1 *> sep_by vs mem  <* rcb >>| fun ms -> `Object ms in
+    let arr = advance1 *> sep_by vs json <* rsb >>| fun vs -> `Array  vs in
+    let str = advance1 *> str >>| fun s -> `String s in
     ws *> peek_char_fail
     >>= function
       | 'f' -> _false


### PR DESCRIPTION
```
┌────────────────┬──────────┬─────────┬────────────┐
│ Name           │ Time/Run │ mWd/Run │ Percentage │
├────────────────┼──────────┼─────────┼────────────┤
│ peek_char_fail │  11.09ns │   9.00w │     62.85% │
│ any_char       │  12.62ns │   9.00w │     71.49% │
│ char           │  15.75ns │  15.00w │     89.22% │
│ not_char       │  17.65ns │  15.00w │    100.00% │
│ advance 1      │   8.24ns │   9.00w │     46.69% │
└────────────────┴──────────┴─────────┴────────────┘
```