### PR TITLE
optimize uses of count_while

### DIFF
--- a/benchmarks/pure_benchmark.ml
+++ b/benchmarks/pure_benchmark.ml
@@ -82,6 +82,16 @@ let main () =
       make_bench "advance 1"      (advance 1)    contents;
     ]
   in
+  let loops =
+    let contents = Bigstring.of_string (String.make 1024 'a') in
+    let open Angstrom in
+    Bench.make_command [
+      make_bench "skip_while  true" (skip_while  (fun _ -> true)) contents;
+      make_bench "take_while  true" (take_while  (fun _ -> true)) contents;
+      make_bench "take_while1 true" (take_while1 (fun _ -> true)) contents;
+      make_bench "many any_char "   (many any_char)               contents;
+    ]
+  in
   Command.run
     (Command.group ~summary:"various angstrom benchmarks" 
       [ "json"      , json
@@ -89,6 +99,7 @@ let main () =
       ; "http"      , http
       ; "numbers"   , numbers
       ; "characters", characters
+      ; "loops"     , loops
     ])
 
 let () = main ()

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -156,6 +156,12 @@ let basic_constructors =
       check_s ~msg:"false, non-empty input" (take_while (fun _ -> false)) ["asdf"] "";
       check_s ~msg:"false, empty input"     (take_while (fun _ -> false)) [""] "";
   end
+  ; "take_while1", `Quick, begin fun () ->
+      check_s ~msg:"true, non-empty input"     (take_while1 (fun _ -> true)) ["asdf"] "asdf";
+      check_fail ~msg:"false, non-empty input" (take_while1 (fun _ -> false)) ["asdf"];
+      check_fail ~msg:"true, empty input"      (take_while1 (fun _ -> true)) [""];
+      check_fail ~msg:"false, empty input"     (take_while1 (fun _ -> false)) [""];
+  end
   ]
 
 module Bigstring = Angstrom__Bigstring (* trollface *)


### PR DESCRIPTION
The `count_while f >>= advance` pattern was a signifcant source of parser allocations. Elminiate that pattern by passing a `with_buffer` function to count_while, which will be passed a view into the input that count_while will consume. The result of `with_buffer` is now the result of the parser.

This pull request also adds some looping benchmarks that were used to evaluate the change, together with existing json benchmarks.

## Loops
Before:
```
┌──────────────────┬──────────┬────────────┬──────────┬──────────┬───────────┬──────────┬────────────┐
│ Name             │ Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │   mGC/Run │ mjGC/Run │ Percentage │
├──────────────────┼──────────┼────────────┼──────────┼──────────┼───────────┼──────────┼────────────┤
│ skip_while  true │   1.92us │     23.00w │          │          │   0.09e-3 │          │      5.00% │
│ take_while  true │   2.00us │    154.00w │          │          │   0.59e-3 │          │      5.19% │
│ take_while1 true │   1.98us │    154.00w │          │          │   0.59e-3 │          │      5.15% │
│ many any_char    │  38.45us │ 27_708.62w │  861.59w │  861.59w │ 107.95e-3 │  4.51e-3 │    100.00% │
└──────────────────┴──────────┴────────────┴──────────┴──────────┴───────────┴──────────┴────────────┘
```
After:
```
┌──────────────────┬──────────┬────────────┬──────────┬──────────┬───────────┬──────────┬────────────┐
│ Name             │ Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │   mGC/Run │ mjGC/Run │ Percentage │
├──────────────────┼──────────┼────────────┼──────────┼──────────┼───────────┼──────────┼────────────┤
│ skip_while  true │   1.97us │      9.00w │          │          │   0.03e-3 │          │      5.04% │
│ take_while  true │   2.01us │    139.00w │          │          │   0.53e-3 │          │      5.15% │
│ take_while1 true │   2.01us │    139.00w │          │          │   0.53e-3 │          │      5.15% │
│ many any_char    │  39.06us │ 27_708.62w │  859.56w │  859.56w │ 107.96e-3 │  4.51e-3 │    100.00% │
└──────────────────┴──────────┴────────────┴──────────┴──────────┴───────────┴──────────┴────────────┘
```

## JSON

Before:
```
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬──────────────┬───────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │      mGC/Run │  mjGC/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼──────────────┼───────────┼────────────┤
│ twitter1    │     15.87us │     7.14kw │       9.64w │       9.64w │     27.29e-3 │   0.09e-3 │      0.14% │
│ twitter10   │    108.80us │    44.22kw │     255.19w │     255.19w │    169.65e-3 │   1.96e-3 │      0.94% │
│ twitter20   │    213.00us │    87.34kw │     714.45w │     714.45w │    335.50e-3 │   4.60e-3 │      1.84% │
│ twitter-big │ 11_576.81us │ 3_482.93kw │ 190_347.26w │ 190_347.26w │ 13_776.24e-3 │ 844.32e-3 │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴──────────────┴───────────┴────────────┘
```
After:
```
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬─────────────┬───────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │     mGC/Run │  mjGC/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼─────────────┼───────────┼────────────┤
│ twitter1    │     14.25us │     4.92kw │       6.49w │       6.49w │    18.81e-3 │   0.06e-3 │      0.13% │
│ twitter10   │     99.29us │    30.52kw │     174.91w │     174.91w │   117.12e-3 │   1.35e-3 │      0.88% │
│ twitter20   │    192.65us │    59.56kw │     651.76w │     651.76w │   229.27e-3 │   4.22e-3 │      1.71% │
│ twitter-big │ 11_252.43us │ 2_381.33kw │ 184_363.54w │ 184_363.54w │ 9_467.42e-3 │ 701.74e-3 │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴─────────────┴───────────┴────────────┘
```
