### PR TITLE
eliminate-caml_equal: slipped through

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -384,7 +384,9 @@ let string_ f s =
   let len = String.length s in
   ensure_apply_opt len ~f:(fun buffer ~off ~len ->
     let i = ref 0 in
-    while !i < len && f (Bigstring.unsafe_get buffer (off + !i)) = f (String.unsafe_get s !i) do
+    while !i < len && Char.equal (f (Bigstring.unsafe_get buffer (off + !i)))
+                                 (f (String.unsafe_get s !i))
+    do
       incr i
     done;
     if len = !i


### PR DESCRIPTION
`caml_equal`'s an indirect call, it should be avoided.