### PR TITLE
Input module reorg

### DIFF
--- a/async/angstrom_async.ml
+++ b/async/angstrom_async.ml
@@ -50,9 +50,9 @@ let rec finalize state result =
   match state, result with
   | Partial p, `Eof_with_unconsumed_data s ->
     let bigstring = Bigstring.of_string s in
-    finalize (p.continue bigstring Complete) `Eof
+    finalize (p.continue bigstring ~off:0 ~len:(String.length s) Complete) `Eof
   | Partial p, `Eof                        ->
-    finalize (p.continue empty_bigstring Complete) `Eof
+    finalize (p.continue empty_bigstring ~off:0 ~len:0 Complete) `Eof
   | Partial _, `Stopped () -> assert false
   | state    , _           -> state_to_result state
 
@@ -68,7 +68,7 @@ let parse ?(pushback=default_pushback) p reader =
   let handle_chunk buf ~pos ~len =
     begin match !state with
     | Partial p ->
-      state := p.continue (Bigstring.sub_shared ~pos ~len buf) Incomplete;
+      state := p.continue buf ~off:pos ~len Incomplete;
     | _         -> ()
     end;
     pushback () >>| fun () -> response !state

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -487,7 +487,7 @@ module Buffered : sig
     | Done    of unconsumed * 'a (** The parser succeeded. *)
     | Fail    of unconsumed * string list * string (** The parser failed. *)
 
-  val parse : ?initial_buffer_size:int -> ?input:input -> 'a t -> 'a state
+  val parse : ?initial_buffer_size:int -> 'a t -> 'a state
   (** [parse ?initial_buffer_size ?input t] runs [t] on [input], if present,
       and awaits input if needed. [parse] will allocate a buffer of size
       [initial_buffer_size] (defaulting to 4k bytes) to do input buffering and
@@ -542,7 +542,6 @@ module Unbuffered : sig
     | Complete
     | Incomplete
 
-
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
     | Done    of int * 'a (** The parser succeeded, consuming specified bytes. *)
@@ -552,14 +551,14 @@ module Unbuffered : sig
       (** The number of bytes committed during the last input feeding.
           Callers must drop this number of bytes from the beginning of the
           input on subsequent calls. See {!commit} for additional details. *)
-    ; continue : bigstring -> more -> 'a state
+    ; continue : bigstring -> off:int -> len:int -> more -> 'a state
       (** A continuation of a parse that requires additional input. The input
           should include all uncommitted input (as reported by previous partial
           states) in addition to any new input that has become available, as
           well as an indication of whether there is {!more} input to come.  *)
     }
 
-  val parse : ?input:bigstring -> 'a t -> 'a state
+  val parse : 'a t -> 'a state
   (** [parse ?input t] runs [t] on [input], if present, and await input if
       needed. *)
 

--- a/lib/input.ml
+++ b/lib/input.ml
@@ -1,29 +1,70 @@
+(*----------------------------------------------------------------------------
+    Copyright (c) 2017 Inhabited Type LLC.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*)
+
 type t =
-  { mutable commit_pos : int
-  ; initial_commit_pos : int
-  ; buffer : Bigstring.t
+  { mutable parser_committed_bytes : int
+  ; client_committed_bytes         : int
+  ; off                            : int
+  ; len                            : int
+  ; buffer                         : Bigstring.t
   }
 
-let create initial_commit_pos buffer =
-  { commit_pos = initial_commit_pos
-  ; initial_commit_pos
-  ; buffer
-  }
+let create buffer ~off ~len ~committed_bytes =
+  { parser_committed_bytes = committed_bytes
+  ; client_committed_bytes = committed_bytes
+  ; off
+  ; len
+  ; buffer }
 
-let length t =
-  Bigstring.length t.buffer + t.initial_commit_pos
+let length                 t = t.client_committed_bytes + t.len
+let client_committed_bytes t = t.client_committed_bytes
+let parser_committed_bytes t = t.parser_committed_bytes
 
-let committed_bytes t =
-  t.commit_pos - t.initial_commit_pos
+let committed_bytes_discrepancy t = t.parser_committed_bytes - t.client_committed_bytes
+let bytes_for_client_to_commit  t = committed_bytes_discrepancy t
 
-let initial_commit_pos t = t.initial_commit_pos
-let commit_pos         t = t.commit_pos
+let parser_uncommitted_bytes t = t.len - bytes_for_client_to_commit t
 
-let uncommitted_bytes t =
-  Bigstring.length t.buffer - commit_pos t
+let invariant t =
+  assert (parser_committed_bytes t + parser_uncommitted_bytes t = length t);
+  assert (parser_committed_bytes t - client_committed_bytes   t = bytes_for_client_to_commit t);
+;;
+
+let offset_in_buffer t pos =
+  t.off + pos - t.client_committed_bytes
 
 let apply t pos len ~f =
-  let off = pos - t.initial_commit_pos in
+  let off = offset_in_buffer t pos in
   f t.buffer ~off ~len
 
 let get_char t pos =
@@ -31,12 +72,15 @@ let get_char t pos =
 
 let count_while t pos ~f =
   let buffer = t.buffer in
-  let i = ref (pos - t.initial_commit_pos) in
-  let len = Bigstring.length buffer in
+  let off    = offset_in_buffer t pos in
+  let i      = ref off in
+  let len    = t.len in
   while !i < len && f (Bigstring.unsafe_get buffer !i) do 
     incr i
   done;
-  !i - (pos - t.initial_commit_pos)
+  !i - off
+;;
 
 let commit t pos =
-  t.commit_pos <- pos
+  t.parser_committed_bytes <- pos
+;;

--- a/lib/input.mli
+++ b/lib/input.mli
@@ -1,13 +1,47 @@
+(*----------------------------------------------------------------------------
+    Copyright (c) 2017 Inhabited Type LLC.
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of the author nor the names of his contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+    OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+  ----------------------------------------------------------------------------*)
+
 type t
 
-val create : int -> Bigstring.t -> t
+val create : Bigstring.t -> off:int -> len:int -> committed_bytes:int -> t
 
 val length : t -> int
 
-val initial_commit_pos : t -> int
-val uncommitted_bytes  : t -> int
-val committed_bytes    : t -> int
-val commit_pos         : t -> int
+val client_committed_bytes   : t -> int
+val parser_committed_bytes   : t -> int
+val parser_uncommitted_bytes : t -> int
+
+val bytes_for_client_to_commit : t -> int
 
 val get_char    : t -> int -> char
 val count_while : t -> int -> f:(char -> bool) -> int
@@ -15,3 +49,5 @@ val count_while : t -> int -> f:(char -> bool) -> int
 val apply : t -> int -> int -> f:(Bigstring.t -> off:int -> len:int -> 'a) -> 'a
 
 val commit : t -> int -> unit
+
+val invariant : t -> unit

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -4,7 +4,7 @@ type 'a state =
   | Fail    of int * string list * string
 and 'a partial =
   { committed : int
-  ; continue  : Bigstring.t -> More.t -> 'a state }
+  ; continue  : Bigstring.t -> off:int -> len:int -> More.t -> 'a state }
 
 type 'a with_state = Input.t ->  int -> More.t -> 'a
 
@@ -14,8 +14,8 @@ type ('a, 'r) success = ('a -> 'r state) with_state
 type 'a t =
   { run : 'r. ('r failure -> ('a, 'r) success -> 'r state) with_state }
 
-let fail_k    buf pos _ marks msg = Fail(pos - Input.initial_commit_pos buf, marks, msg)
-let succeed_k buf pos _       v   = Done(pos - Input.initial_commit_pos buf, v)
+let fail_k    input pos _ marks msg = Fail(pos - Input.client_committed_bytes input, marks, msg)
+let succeed_k input pos _       v   = Done(pos - Input.client_committed_bytes input, v)
 
 let fail_to_string marks err =
   String.concat " > " marks ^ ": " ^ err
@@ -29,11 +29,13 @@ let state_to_result = function
   | Partial _           -> Result.Error "incomplete input"
   | Fail(_, marks, err) -> Result.Error (fail_to_string marks err)
 
-let parse ?(input=Bigstring.empty) p =
-  p.run (Input.create 0 input) 0 Incomplete fail_k succeed_k
+let parse p =
+  let input = Input.create Bigstring.empty ~committed_bytes:0 ~off:0 ~len:0 in
+  p.run input 0 Incomplete fail_k succeed_k
 
 let parse_bigstring p input =
-  state_to_result (p.run (Input.create 0 input) 0 Complete fail_k succeed_k)
+  let input = Input.create input ~committed_bytes:0 ~off:0 ~len:(Bigstring.length input) in
+  state_to_result (p.run input 0 Complete fail_k succeed_k)
 
 module Monad = struct
   let return =
@@ -139,7 +141,7 @@ module Choice = struct
          * of the committed input, then calling the failure continuation will
          * have the effect of unwinding all choices and collecting marks along
          * the way. *)
-        if pos < Input.commit_pos input' then
+        if pos < Input.client_committed_bytes input' then
           fail input' pos' more marks msg
         else
           q.run input' pos more' fail succ in


### PR DESCRIPTION
The names of functions from the input module were pretty bad. This commit fixes that and in the process expands functionality of the unbuffered interface. Rather than requiring a bigstring as an input, the client can specify a range of bytes to use as input within the bigstring, specified by the `off` and `len` arguments of the `continue` field of the `partial` types. These changes had to be propagated through the unbuffered interface as well.

To simplify implementation at a negligible cost to user convenience, the `parse` functions in both the `Unbuffered` and `Buffered` modules no long take an initial input as an argument. For one-shot parses, there are already convenience functions for that. In other words if you're using these modules then you probably already have an input driver lying around somewhere that you can use for initial, and subsequent, input chunks.