### PR TITLE
return: use function definition syntax

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -38,11 +38,10 @@ let parse_bigstring p input =
   state_to_result (p.run input 0 Complete fail_k succeed_k)
 
 module Monad = struct
-  let return =
-    fun v ->
-      { run = fun input pos more _fail succ ->
-        succ input pos more v
-      }
+  let return v =
+    { run = fun input pos more _fail succ ->
+      succ input pos more v
+    }
 
   let fail msg =
     { run = fun input pos more fail _succ ->


### PR DESCRIPTION
For some reason `Monad.return` was being defined as an anonymous function being assigned to an identifier. Just turn it into a regular function definition.

Not sure why it was like that to begin with.