### PR TITLE
bad-check: remove redundant check that hid a bug

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -155,7 +155,7 @@ let rec prompt input pos fail succ =
     if len < parser_uncommitted_bytes then
       failwith "prompt: input shrunk!";
     let input = Input.create input ~off ~len ~committed_bytes:parser_committed_bytes in
-    if len = parser_uncommitted_bytes || pos = Input.length input then
+    if len = parser_uncommitted_bytes then
       match (more : More.t) with
       | Complete   -> fail input pos More.Complete
       | Incomplete -> prompt input pos fail succ


### PR DESCRIPTION
This reverses the fix introduced by #104, which actually hid a bug in the old `Input.uncommitted_bytes`. That function  using the buffer length rather than the input length to compute the number of uncommitted bytes. As part of the refactoring performed in #123, this bug was fixed. So despite the removal of the fix in #104, the test introduced in the same pull request continues to pass.