### PR TITLE
Add constant-checking int parsers

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -506,25 +506,68 @@ let scan_string state f =
   scan state f >>| fst
 
 module BE = struct
-  let uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_be bs off)
-  let int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_be  bs off)
+  let int16 n =
+    ensure 2 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int16_be input pos = (n land 0xffff)
+      then succ input (pos + 2) more ()
+      else fail input pos more [] "int16" }
 
-  let int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_be bs off)
-  let int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_be bs off)
+  let int32 n =
+    ensure 4 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int32_be input pos = n
+      then succ input (pos + 4) more ()
+      else fail input pos more [] "int32" }
 
-  let float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_be bs off))
-  let double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_be bs off))
+  let int64 n =
+    ensure 8 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int64_be input pos = n
+      then succ input (pos + 8) more ()
+      else fail input pos more [] "int64" }
+
+  let any_uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_be bs off)
+  let any_int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_be  bs off)
+
+  let any_int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_be bs off)
+  let any_int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_be bs off)
+
+  let any_float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_be bs off))
+  let any_double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_be bs off))
 end
 
 module LE = struct
-  let uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_le bs off)
-  let int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_le bs off)
 
-  let int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_le bs off)
-  let int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_le bs off)
+  let int16 n =
+    ensure 2 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int16_le input pos = (n land 0xffff)
+      then succ input (pos + 2) more ()
+      else fail input pos more [] "int16" }
 
-  let float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_le bs off))
-  let double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off))
+  let int32 n =
+    ensure 4 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int32_le input pos = n
+      then succ input (pos + 4) more ()
+      else fail input pos more [] "int32" }
+
+  let int64 n =
+    ensure 8 *>
+    { run = fun input pos more fail succ ->
+      if Input.get_int64_le input pos = n
+      then succ input (pos + 8) more ()
+      else fail input pos more [] "int64" }
+
+  let any_uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_le bs off)
+  let any_int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_le bs off)
+
+  let any_int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_le bs off)
+  let any_int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_le bs off)
+
+  let any_float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_le bs off))
+  let any_double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off))
 end
 
 module Unsafe = struct

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -31,7 +31,7 @@
     POSSIBILITY OF SUCH DAMAGE.
   ----------------------------------------------------------------------------*)
 
-module Bigarray = struct 
+module Bigarray = struct
   (* Do not access Bigarray operations directly. If anything's needed, refer to
    * the internal Bigstring module. *)
 end
@@ -197,15 +197,13 @@ let unsafe_apply_opt len ~f =
     | Ok    x -> succ input (pos + len) more x
   }
 
-let ensure n =
+let ensure n p =
   { run = fun input pos more fail succ ->
-    if pos + n <= Input.length input then
-      succ input pos more ()
+    if pos + n <= Input.length input
+    then p.run input pos more fail succ
     else
-      ensure_suspended n input pos more fail succ }
-
-let ensure_apply     n ~f = ensure n *> unsafe_apply     n ~f
-let ensure_apply_opt n ~f = ensure n *> unsafe_apply_opt n ~f
+      let succ' input' pos' more' () = p.run input' pos' more' fail succ in
+      ensure_suspended n input pos more fail succ' }
 
 (** END: getting input *)
 
@@ -381,7 +379,7 @@ let string_ f s =
   (* XXX(seliopou): Inefficient. Could check prefix equality to short-circuit
    * the io. *)
   let len = String.length s in
-  ensure_apply_opt len ~f:(fun buffer ~off ~len ->
+  ensure  len (unsafe_apply_opt len ~f:(fun buffer ~off ~len ->
     let i = ref 0 in
     while !i < len && Char.equal (f (Bigstringaf.unsafe_get buffer (off + !i)))
                                  (f (String.unsafe_get s !i))
@@ -390,7 +388,7 @@ let string_ f s =
     done;
     if len = !i
     then Ok (Bigstringaf.substring buffer ~off ~len)
-    else Error "string")
+    else Error "string"))
 
 let string s    = string_ (fun x -> x) s
 let string_ci s = string_ Char.lowercase_ascii s
@@ -399,10 +397,12 @@ let skip_while f =
   count_while ~init:0 ~f ~with_buffer:(fun _ ~off:_ ~len:_ -> ())
 
 let take n =
-  ensure_apply (max n 0) ~f:Bigstringaf.substring
+  let n = max n 0 in
+  ensure n (unsafe_apply n ~f:Bigstringaf.substring)
 
 let take_bigstring n =
-  ensure_apply (max n 0) ~f:Bigstringaf.copy
+  let n = max n 0 in
+  ensure n (unsafe_apply n ~f:Bigstringaf.copy)
 
 let take_bigstring_while f =
   count_while ~init:0 ~f ~with_buffer:Bigstringaf.copy
@@ -506,73 +506,123 @@ let scan_string state f =
   scan state f >>| fst
 
 module BE = struct
+  (* XXX(seliopou): The pattern in both this module and [LE] are a compromise
+   * between efficiency and code reuse. By inlining [ensure] you can recover
+   * about 2 nanoseconds on average. That may add up in certain applications.
+   *
+   * This pattern does not allocate in the fast (success) path.
+   * *)
   let int16 n =
-    ensure 2 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int16_be input pos = (n land 0xffff)
-      then succ input (pos + 2) more ()
-      else fail input pos more [] "int16" }
+    let bytes = 2 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Input.get_int16_be input pos = (n land 0xffff)
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int16" }
+    in
+    ensure bytes p
 
   let int32 n =
-    ensure 4 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int32_be input pos = n
-      then succ input (pos + 4) more ()
-      else fail input pos more [] "int32" }
+    let bytes = 4 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Int32.equal (Input.get_int32_be input pos) n
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int32" }
+    in
+    ensure bytes p
 
   let int64 n =
-    ensure 8 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int64_be input pos = n
-      then succ input (pos + 8) more ()
-      else fail input pos more [] "int64" }
+    let bytes = 8 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Int64.equal (Input.get_int64_be input pos) n
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int64" }
+    in
+    ensure bytes p
 
-  let any_uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_be bs off)
-  let any_int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_be  bs off)
+  let any_uint16 =
+    ensure 2 (unsafe_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_be bs off))
 
-  let any_int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_be bs off)
-  let any_int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_be bs off)
+  let any_int16  =
+    ensure 2 (unsafe_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_be  bs off))
 
-  let any_float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_be bs off))
-  let any_double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_be bs off))
+  let any_int32  =
+    ensure 4 (unsafe_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_be bs off))
+
+  let any_int64 =
+    ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_be bs off))
+
+  let any_float =
+    ensure 4 (unsafe_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_be bs off)))
+
+  let any_double =
+    ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_be bs off)))
 end
 
 module LE = struct
 
   let int16 n =
-    ensure 2 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int16_le input pos = (n land 0xffff)
-      then succ input (pos + 2) more ()
-      else fail input pos more [] "int16" }
+    let bytes = 2 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Input.get_int16_le input pos = (n land 0xffff)
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int16" }
+    in
+    ensure bytes p
 
   let int32 n =
-    ensure 4 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int32_le input pos = n
-      then succ input (pos + 4) more ()
-      else fail input pos more [] "int32" }
+    let bytes = 4 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Int32.equal (Input.get_int32_le input pos) n
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int32" }
+    in
+    ensure bytes p
 
   let int64 n =
-    ensure 8 *>
-    { run = fun input pos more fail succ ->
-      if Input.get_int64_le input pos = n
-      then succ input (pos + 8) more ()
-      else fail input pos more [] "int64" }
+    let bytes = 8 in
+    let p =
+      { run = fun input pos more fail succ ->
+        if (pos + bytes : int) <= Input.length input
+        && Int64.equal (Input.get_int64_le input pos) n
+        then succ input (pos + bytes) more ()
+        else fail input pos more [] "BE.int64" }
+    in
+    ensure bytes p
 
-  let any_uint16 = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_le bs off)
-  let any_int16  = ensure_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_le bs off)
 
-  let any_int32  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_le bs off)
-  let any_int64  = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_le bs off)
+  let any_uint16 =
+    ensure 2 (unsafe_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_le bs off))
 
-  let any_float  = ensure_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_le bs off))
-  let any_double = ensure_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off))
+  let any_int16  =
+    ensure 2 (unsafe_apply 2 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int16_sign_extended_le  bs off))
+
+  let any_int32  =
+    ensure 4 (unsafe_apply 4 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int32_le bs off))
+
+  let any_int64 =
+    ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Bigstringaf.unsafe_get_int64_le bs off))
+
+  let any_float =
+    ensure 4 (unsafe_apply 4 ~f:(fun bs ~off ~len:_ -> Int32.float_of_bits (Bigstringaf.unsafe_get_int32_le bs off)))
+
+  let any_double =
+    ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off)))
 end
 
 module Unsafe = struct
   let take n f =
-    ensure_apply (max n 0) ~f
+    let n = max n 0 in
+    ensure n (unsafe_apply n ~f)
 
   let peek n f =
     unsafe_lookahead (take n f)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -188,8 +188,16 @@ val any_int8 : int t
 (** Big endian parsers *)
 module BE : sig
   val int16 : int   -> unit t
+  (** [int16 i] accept two bytes that match the two lower order bytes of [i]
+      and returns unit. *)
+
   val int32 : int32 -> unit t
+  (** [int32 i] accept four bytes that match the four bytes of [i]
+      and returns unit. *)
+
   val int64 : int64 -> unit t
+  (** [int32 i] accept eight bytes that match the eight bytes of [i] and
+      returns unit. *)
 
   val any_int16 : int t
   val any_int32 : int32 t
@@ -212,8 +220,16 @@ end
 (** Little endian parsers *)
 module LE : sig
   val int16 : int   -> unit t
+  (** [int16 i] accept two bytes that match the two lower order bytes of [i]
+      and returns unit. *)
+
   val int32 : int32 -> unit t
+  (** [int32 i] accept four bytes that match the four bytes of [i]
+      and returns unit. *)
+
   val int64 : int64 -> unit t
+  (** [int32 i] accept eight bytes that match the eight bytes of [i] and
+      returns unit. *)
 
   val any_int16 : int t
   val any_int32 : int32 t

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -187,42 +187,50 @@ val any_int8 : int t
 
 (** Big endian parsers *)
 module BE : sig
-  val int16 : int t
-  val int32 : int32 t
-  val int64 : int64 t
-  (** [intN] reads [N] bits and interprets them as big endian signed integers. *)
+  val int16 : int   -> unit t
+  val int32 : int32 -> unit t
+  val int64 : int64 -> unit t
 
-  val uint16 : int t
-  (** [uint16] reads [16] bits and interprets them as a big endian unsigned
+  val any_int16 : int t
+  val any_int32 : int32 t
+  val any_int64 : int64 t
+  (** [any_intN] reads [N] bits and interprets them as big endian signed integers. *)
+
+  val any_uint16 : int t
+  (** [any_uint16] reads [16] bits and interprets them as a big endian unsigned
       integer. *)
 
-  val float : float t
-  (** [float] reads 32 bits and interprets them as a big endian floating
+  val any_float : float t
+  (** [any_float] reads 32 bits and interprets them as a big endian floating
       point value. *)
 
-  val double : float t
-  (** [double] reads 64 bits and interprets them as a big endian floating
+  val any_double : float t
+  (** [any_double] reads 64 bits and interprets them as a big endian floating
       point value. *)
 end
 
 (** Little endian parsers *)
 module LE : sig
-  val int16 : int t
-  val int32 : int32 t
-  val int64 : int64 t
-  (** [intN] reads [N] bits and interprets them as little endian signed
+  val int16 : int   -> unit t
+  val int32 : int32 -> unit t
+  val int64 : int64 -> unit t
+
+  val any_int16 : int t
+  val any_int32 : int32 t
+  val any_int64 : int64 t
+  (** [any_intN] reads [N] bits and interprets them as little endian signed
       integers. *)
 
-  val uint16 : int t
+  val any_uint16 : int t
   (** [uint16] reads [16] bits and interprets them as a little endian unsigned
       integer. *)
 
-  val float : float t
-  (** [float] reads 32 bits and interprets them as a little endian floating
+  val any_float : float t
+  (** [any_float] reads 32 bits and interprets them as a little endian floating
       point value. *)
 
-  val double : float t
-  (** [double] reads 64 bits and interprets them as a little endian floating
+  val any_double : float t
+  (** [any_double] reads 64 bits and interprets them as a little endian floating
       point value. *)
 end
 

--- a/lib/input.ml
+++ b/lib/input.ml
@@ -68,7 +68,32 @@ let apply t pos len ~f =
   f t.buffer ~off ~len
 
 let get_char t pos =
-  apply t pos 1 ~f:(fun buf ~off ~len:_ -> Bigstringaf.unsafe_get buf off)
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get t.buffer off
+
+let get_int16_le t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int16_le t.buffer off
+
+let get_int32_le t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int32_le t.buffer off
+
+let get_int64_le t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int64_le t.buffer off
+
+let get_int16_be t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int16_be t.buffer off
+
+let get_int32_be t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int32_be t.buffer off
+
+let get_int64_be t pos =
+  let off = offset_in_buffer t pos in
+  Bigstringaf.unsafe_get_int64_be t.buffer off
 
 let count_while t pos ~f =
   let buffer = t.buffer in

--- a/lib/input.mli
+++ b/lib/input.mli
@@ -43,7 +43,14 @@ val parser_uncommitted_bytes : t -> int
 
 val bytes_for_client_to_commit : t -> int
 
-val get_char    : t -> int -> char
+val get_char     : t -> int -> char
+val get_int16_le : t -> int -> int
+val get_int32_le : t -> int -> int32
+val get_int64_le : t -> int -> int64
+val get_int16_be : t -> int -> int
+val get_int32_be : t -> int -> int32
+val get_int64_be : t -> int -> int64
+
 val count_while : t -> int -> f:(char -> bool) -> int
 
 val apply : t -> int -> int -> f:(Bigstringaf.t -> off:int -> len:int -> 'a) -> 'a

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -195,12 +195,12 @@ module Endian(Es : EndianBigstring) = struct
   module type EndianSig = module type of LE
 
   let tests (module E : EndianSig) = [
-    make_tests int16  E.int16;
-    make_tests int32  E.int32;
-    make_tests int64  E.int64;
-    make_tests uint16 E.uint16;
-    make_tests float  E.float;
-    make_tests double E.double;
+    make_tests int16  E.any_int16;
+    make_tests int32  E.any_int32;
+    make_tests int64  E.any_int64;
+    make_tests uint16 E.any_uint16;
+    make_tests float  E.any_float;
+    make_tests double E.any_double;
   ]
 end
 let little_endian =


### PR DESCRIPTION
Add int parsers that take various int types as an argument and ensure that the corresponding number of bytes match the beginning of the input.

These parsers are useful for checking protocol constants, and should be more efficient than the newly-named `any_intN` parsers. These previous parsers required a bind in order to perform this check, whereas the new parsers do not.

In addition to adding these new parsers, which were more efficient than the previous alternatives, an internal refactoring improved the performance and allocation requirements of the `any_intN` parsers and the `string` parser. Here's a benchmark for parsers that check for a `"\r\n"` sequence before (including the initial implementation of the new parsers):

```
┌────────────────────┬──────────┬─────────┬────────────┐
│ Name               │ Time/Run │ mWd/Run │ Percentage │
├────────────────────┼──────────┼─────────┼────────────┤
│ string "\r\n"      │  35.34ns │  22.00w │    100.00% │
│ BE.any_int16 >>= f │  28.07ns │  32.00w │     79.43% │
│ BE.int16 0x0d0a    │  18.11ns │  18.00w │     51.26% │
│ LE.int16 0x0a0d    │  17.22ns │  18.00w │     48.75% │
└────────────────────┴──────────┴─────────┴────────────┘
```

Here are the benchmarks after the internal refactoring:

```
┌────────────────────┬──────────┬─────────┬────────────┐
│ Name               │ Time/Run │ mWd/Run │ Percentage │
├────────────────────┼──────────┼─────────┼────────────┤
│ string "\r\n"      │  30.99ns │  15.00w │    100.00% │
│ BE.any_int16 >>= f │  23.86ns │  25.00w │     76.98% │
│ BE.int16 0x0d0a    │  14.27ns │  11.00w │     46.05% │
│ LE.int16 0x0a0d    │  13.66ns │  11.00w │     44.06% │
└────────────────────┴──────────┴─────────┴────────────┘
```