### PR TITLE
choice-error: add an optional `failure_msg` argument to `choice`

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -425,8 +425,8 @@ let take_while1 f =
 let take_till f =
   take_while (fun c -> not (f c))
 
-let choice ps =
-  List.fold_right (<|>) ps (fail "empty")
+let choice ?(failure_msg="no more choices") ps =
+  List.fold_right (<|>) ps (fail failure_msg)
 
 let fix f =
   let rec p = lazy (f r)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -338,9 +338,11 @@ val (<|>) : 'a t -> 'a t -> 'a t
 (** [p <|> q] runs [p] and returns the result if succeeds. If [p] fails, then
     the input will be reset and [q] will run instead. *)
 
-val choice : 'a t list -> 'a t
-(** [choice ts] runs each parser in [ts] in order until one succeeds and
-    returns that result. *)
+val choice : ?failure_msg:string -> 'a t list -> 'a t
+(** [choice ?message ts] runs each parser in [ts] in order until one succeeds
+    and returns that result. In the case that none of the parser succeeds, then
+    the parser will fail with the message [failure_msg], if provided, or a
+    much less informative message otherwise. *)
 
 val (<?>) : 'a t -> string -> 'a t
 (** [p <?> name] associates [name] with the parser [p], which will be reported


### PR DESCRIPTION
This can be used to quickly identify which choice resulted in the failure of the parser. In the absence of `commit`, it's always the first choice encountered, but it gets trickier when a parser does use choice. In that case it's the first choice encountered after the last `commit`.

Closes #136.