### PR TITLE
fix-choice-commit: check parser_committed_bytes

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -140,7 +140,7 @@ module Choice = struct
          * of the committed input, then calling the failure continuation will
          * have the effect of unwinding all choices and collecting marks along
          * the way. *)
-        if pos < Input.client_committed_bytes input' then
+        if pos < Input.parser_committed_bytes input' then
           fail input' pos' more marks msg
         else
           q.run input' pos more' fail succ in

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -347,6 +347,19 @@ let count_while_regression =
       (take_while1 (fun _ -> true) <* end_of_input) ["asdf"; ""] "asdf";
   end ]
 
+let choice_commit = 
+  [ "", `Quick, begin fun () ->
+    let p = 
+      choice  [ string "@@" *> commit *> char '*'
+              ; string "@"  *> commit *> char '!' ]
+    in
+    Alcotest.(check (result reject string))
+      "commit to branch"
+      (Error ": char '*'")
+      (parse_string p "@@^");
+  end ]
+
+
 let () =
   Alcotest.run "test suite"
     [ "basic constructors"    , basic_constructors
@@ -358,4 +371,5 @@ let () =
     ; "combinators"           , combinators
     ; "incremental input"     , incremental 
     ; "count_while regression", count_while_regression
+    ; "choice and commit"     , choice_commit
   ]


### PR DESCRIPTION
The failure contination in choice was previously checking `client_committed_bytes` to determine if it was OK to backtrack to the previous position to try the next branch of the choice. The code should have been checking `parser_committed_bytes` instead, which is the value that's actually updated by the `commit` parser.

Added a test to catch this in the future.

Closes #144.