### PR TITLE
lwt: implement parse_with_buffered_state

### DIFF
--- a/angstrom-async.descr
+++ b/angstrom-async.descr
@@ -1,1 +1,0 @@
-Angstrom - Async-specific support

--- a/angstrom-async.opam
+++ b/angstrom-async.opam
@@ -1,21 +1,20 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "angstrom-async"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
-dev-repo: "https://github.com/inhabitedtype/angstrom.git"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["jbuilder" "runtest" "-p" name]
+  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "angstrom" {>= "0.7.0"}
-  "async"    {>= "v0.9.0"}
+  "async" {>= "v0.9.0"}
 ]
-available: [ ocaml-version >= "4.03.0" ]
+synopsis: "Async support for Angstrom"

--- a/angstrom-lwt-unix.descr
+++ b/angstrom-lwt-unix.descr
@@ -1,1 +1,0 @@
-Angstrom - Lwt- and Unix-specific support

--- a/angstrom-lwt-unix.opam
+++ b/angstrom-lwt-unix.opam
@@ -1,21 +1,20 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
-dev-repo: "https://github.com/inhabitedtype/angstrom.git"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["jbuilder" "runtest" "-p" name]
+  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "angstrom"
   "lwt"
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+synopsis: "Lwt_unix support for Angstrom"

--- a/angstrom-unix.descr
+++ b/angstrom-unix.descr
@@ -1,1 +1,0 @@
-Angstrom - Unix-specific support

--- a/angstrom-unix.opam
+++ b/angstrom-unix.opam
@@ -1,20 +1,19 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
-dev-repo: "https://github.com/inhabitedtype/angstrom.git"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["jbuilder" "runtest" "-p" name]
+  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
   "angstrom"
   "base-unix"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+synopsis: "Unix support for Angstrom"

--- a/angstrom.descr
+++ b/angstrom.descr
@@ -1,9 +1,0 @@
-Parser combinators built for speed and memory-efficiency
-
-Angstrom is a parser-combinator library that makes it easy to write efficient,
-expressive, and reusable parsers suitable for high-performance applications. It
-exposes monadic and applicative interfaces for composition, and supports
-incremental input through buffered and unbuffered interfaces. Both interfaces
-give the user total control over the blocking behavior of their application,
-with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
-default and support unbounded lookahead.

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -1,20 +1,28 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"
 homepage: "https://github.com/inhabitedtype/angstrom"
 bug-reports: "https://github.com/inhabitedtype/angstrom/issues"
-dev-repo: "https://github.com/inhabitedtype/angstrom.git"
+dev-repo: "git+https://github.com/inhabitedtype/angstrom.git"
 build: [
-  ["jbuilder" "subst"] {pinned}
+  ["jbuilder" "subst" "-p" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["jbuilder" "runtest" "-p" name]
+  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "jbuilder" {build & >= "1.0+beta10"}
-  "alcotest" {test & >= "0.8.1"}
+  "alcotest" {with-test & >= "0.8.1"}
   "bigstringaf"
+  "result"
 ]
-available: [ ocaml-version >= "4.03.0" ]
+synopsis: "Parser combinators built for speed and memory-efficiency"
+description: """
+Angstrom is a parser-combinator library that makes it easy to write efficient,
+expressive, and reusable parsers suitable for high-performance applications. It
+exposes monadic and applicative interfaces for composition, and supports
+incremental input through buffered and unbuffered interfaces. Both interfaces
+give the user total control over the blocking behavior of their application,
+with the unbuffered interface enabling zero-copy IO. Parsers are backtracking by
+default and support unbounded lookahead."""

--- a/lwt/angstrom_lwt_unix.ml
+++ b/lwt/angstrom_lwt_unix.ml
@@ -62,7 +62,7 @@ let parse ?(pushback=default_pushback) p in_chan =
   buffered_state_loop pushback (parse ~initial_buffer_size:size p) in_chan bytes
   >|= handle_parse_result
 
-let parse_with_buffered_state ?(pushback=default_pushback) state in_chan =
+let with_buffered_parse_state ?(pushback=default_pushback) state in_chan =
   let size  = Lwt_io.buffer_size in_chan in
   let bytes = Bytes.create size in
   begin match state with

--- a/lwt/angstrom_lwt_unix.ml
+++ b/lwt/angstrom_lwt_unix.ml
@@ -36,27 +36,40 @@ open Lwt
 
 let default_pushback () = return_unit
 
+let rec buffered_state_loop pushback state in_chan bytes =
+  let size = Bytes.length bytes in
+  match state with
+  | Partial k ->
+    Lwt_io.read_into in_chan bytes 0 size
+    >|= begin function
+      | 0   -> k `Eof
+      | len ->
+        assert (len > 0);
+        k (`String (Bytes.(unsafe_to_string (sub bytes 0 len))))
+    end
+    >>= fun state' -> pushback ()
+    >>= fun ()     -> buffered_state_loop pushback state' in_chan bytes
+  | state -> return state
+
+let handle_parse_result state =
+  match state_to_unconsumed state with
+  | None    -> assert false
+  | Some us -> us, state_to_result state
+
 let parse ?(pushback=default_pushback) p in_chan =
   let size  = Lwt_io.buffer_size in_chan in
   let bytes = Bytes.create size in
-  let rec loop = function
-    | Partial k ->
-      Lwt_io.read_into in_chan bytes 0 size
-      >|= begin function
-        | 0   -> k `Eof
-        | len ->
-          assert (len > 0);
-          k (`String (Bytes.(unsafe_to_string (sub bytes 0 len))))
-      end
-      >>= fun state' -> pushback ()
-      >>= fun ()     -> loop state'
-    | state -> return state
-  in
-  loop (parse ~initial_buffer_size:size p)
-  >|= fun state ->
-    match state_to_unconsumed state with
-    | None    -> assert false
-    | Some us -> us, state_to_result state
+  buffered_state_loop pushback (parse ~initial_buffer_size:size p) in_chan bytes
+  >|= handle_parse_result
+
+let parse_with_buffered_state ?(pushback=default_pushback) state in_chan =
+  let size  = Lwt_io.buffer_size in_chan in
+  let bytes = Bytes.create size in
+  begin match state with
+  | Partial _ -> buffered_state_loop pushback state in_chan bytes
+  | _         -> return state
+  end
+  >|= handle_parse_result
 
 let async_many e k =
   Angstrom.(skip_many (e <* commit >>| k) <?> "async_many")

--- a/lwt/angstrom_lwt_unix.mli
+++ b/lwt/angstrom_lwt_unix.mli
@@ -61,10 +61,10 @@ val parse_many
         let { buf; off; len } = unconsumed in
         let state = Buffered.parse parser in
         let state = Buffered.feed state (`Bigstring (Bigstringaf.sub ~off ~len buf)) in
-        parse_with_buffered_state state in_channel
+        with_buffered_parse_state state in_channel
       | Error err -> failwith err
     ]} *)
-val parse_with_buffered_state
+val with_buffered_parse_state
   : ?pushback:(unit -> unit Lwt.t)
   -> 'a Buffered.state
   -> Lwt_io.input_channel

--- a/lwt/angstrom_lwt_unix.mli
+++ b/lwt/angstrom_lwt_unix.mli
@@ -34,14 +34,20 @@
 open Angstrom
 
 
-val parse :
-     ?pushback:(unit -> unit Lwt.t)
+val parse
+  : ?pushback:(unit -> unit Lwt.t)
   -> 'a t
   -> Lwt_io.input_channel
   -> (Buffered.unconsumed * ('a, string) result) Lwt.t
 
-val parse_many :
-     'a t
+val parse_with_buffered_state
+  : ?pushback:(unit -> unit Lwt.t)
+  -> 'a Buffered.state
+  -> Lwt_io.input_channel
+  -> (Buffered.unconsumed * ('a, string) result) Lwt.t
+
+val parse_many
+  : 'a t
   -> ('a -> unit Lwt.t)
   -> Lwt_io.input_channel
   -> (Buffered.unconsumed * (unit, string) result) Lwt.t


### PR DESCRIPTION
Allow the resumption of a parse that results in unconsumed data via the
creation of a Buffered parser state.

Closes #154