### PR TITLE
add `consumed` combinator

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -532,6 +532,20 @@ let scan_state state f =
 let scan_string state f =
   scan state f >>| fst
 
+let consume_with p f =
+  { run = fun input pos more fail succ ->
+    let start = pos in
+    let succ' input' pos' more' _ =
+      let len = pos' - start in
+      let consumed = Input.apply input' start len ~f in
+      succ input' pos' more' consumed
+    in
+    p.run input pos more fail succ'
+  }
+
+let consumed           p = consume_with p Bigstringaf.substring
+let consumed_bigstring p = consume_with p Bigstringaf.copy
+
 module BE = struct
   (* XXX(seliopou): The pattern in both this module and [LE] are a compromise
    * between efficiency and code reuse. By inlining [ensure] you can recover

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -292,6 +292,14 @@ val skip_many : _ t -> unit t
 val skip_many1 : _ t -> unit t
 (** [skip_many1 p] runs [p] {i one} or more times, discarding the results. *)
 
+val consumed : _ t -> string t
+(** [consumed p] runs [p] and returns the contents that were consumed during the
+    parsing as a string *)
+
+val consumed_bigstring : _ t -> bigstring t
+(** [consumed p] runs [p] and returns the contents that were consumed during the
+    parsing as a bigstring *)
+
 val fix : ('a t -> 'a t) -> 'a t
 (** [fix f] computes the fixpoint of [f] and runs the resultant parser. The
     argument that [f] receives is the result of [fix f], which [f] must use,

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -126,6 +126,10 @@ val take_till : (char -> bool) -> string t
     This parser does not fail. If [f] returns [true] on the first character, it
     will return the empty string. *)
 
+val consumed : _ t -> string t
+(** [consumed p] runs [p] and returns the contents that were consumed during the
+    parsing as a string *)
+
 val take_bigstring : int -> bigstring t
 (** [take_bigstring n] accepts exactly [n] characters of input and returns them
     as a newly allocated bigstring. *)
@@ -150,6 +154,10 @@ val take_bigstring_till : (char -> bool) -> bigstring t
 
     This parser does not fail. If [f] returns [true] on the first character, it
     will return the empty bigstring. *)
+
+val consumed_bigstring : _ t -> bigstring t
+(** [consumed p] runs [p] and returns the contents that were consumed during the
+    parsing as a bigstring *)
 
 val advance : int -> unit t
 (** [advance n] advances the input [n] characters, failing if the remaining
@@ -291,14 +299,6 @@ val skip_many : _ t -> unit t
 
 val skip_many1 : _ t -> unit t
 (** [skip_many1 p] runs [p] {i one} or more times, discarding the results. *)
-
-val consumed : _ t -> string t
-(** [consumed p] runs [p] and returns the contents that were consumed during the
-    parsing as a string *)
-
-val consumed_bigstring : _ t -> bigstring t
-(** [consumed p] runs [p] and returns the contents that were consumed during the
-    parsing as a bigstring *)
 
 val fix : ('a t -> 'a t) -> 'a t
 (** [fix f] computes the fixpoint of [f] and runs the resultant parser. The

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -300,6 +300,25 @@ let combinators =
         >>| String.concat "" in
       check_s ~msg:"state reset between runs" p ["bcd."] "bcd";
     end
+  ; "consumed", `Quick, begin fun () ->
+      check_s ~msg:"from beginning" (consumed any_char)
+        ["abc"] "a";
+      check_s ~msg:"from middle" (any_char *> consumed any_char)
+        ["abc"] "b";
+      check_c ~msg:"advances input" (any_char *> consumed any_char *> any_char)
+        ["abc"] 'c';
+      check_s ~msg:"with backtracking" (consumed (char 'a' *> (char 'c' <|> char 'b')))
+        ["abc"] "ab";
+      check_s ~msg:"with more input" (consumed (string "abc"))
+        ["a"; "bc"] "abc";
+      let integer =
+        option '+' (char '-') *> take_while (function '0'..'9' -> true | _ -> false)
+      in
+      check_int ~msg:"parsing an integer" (consumed integer >>| int_of_string)
+        ["-12345"] (-12345);
+      check_bs ~msg:"bigstring variant" (consumed_bigstring (string "ab"))
+        ["abc"] (bigstring_of_string "ab");
+    end
   ]
 
 let incremental =


### PR DESCRIPTION
Foreword: I can't tell if this is a weird thing to propose. I don't think I've seen something similar in another parser combinator library, but I don't know how to do the thing I want to do elegantly without it. I think one of the tests best demonstrates what I'm trying to do:

```ocaml
let integer =
  option '+' (char '-') *> take_while (function '0'..'9' -> true | _ -> false)
in
check_int ~msg:"parsing an integer" (consumed integer >>| int_of_string)
  ["-12345"] (-12345)
```

It might seem a little contrived, as I'm using another parser (`int_of_string`) after the `consumed`, but in the case of `jsonaf`, the user provides a similar `string -> 'a` parser outside of the angstrom parsing. Trying to write this without `consumed` means parsing chars and strings and awkwardly concatenating them. But my integer parser is also deceiving because the sign is parsed as `option '+' (char '-')`, yet the `'a` in `option` is completely irrelevant because it isn't ever used, and the whole result is thrown away with the applicative anyway. So I have mixed feelings myself. We could always make the input be a `unit t` to make the intention a little more clear.

---

From the implementation, it is a little strange to call this a
combinator since it manually constructs a parser. This helper is useful
for running a complex series of parsers whose purpose is to "validate" a
substring of input without actually creating a concrete type out of it.
The motivating example for this is parsing numbers in JSON -- you want
to make sure the string conforms to the spec, but you don't actually
want to pull apart the individually parsed pieces just to reconstruct
them into the same string.