### PR TITLE
Fix the `Angstrom.Buffered.state_to_option` docstring

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -535,12 +535,12 @@ module Buffered : sig
       copied into the state's buffer for later use by the caller. *)
 
   val state_to_option : 'a state -> 'a option
-  (** [state_to_option state] returns [Some (bs, v)] if the parser is in the
+  (** [state_to_option state] returns [Some v] if the parser is in the
       [Done (bs, v)] state and [None] otherwise. This function has no effect on
       the current state of the parser. *)
 
   val state_to_result : 'a state -> ('a, string) result
-  (** [state_to_result state] returns [Ok v] if the parser is in the [Done v]
+  (** [state_to_result state] returns [Ok v] if the parser is in the [Done (bs, v)]
       state and [Error msg] if it is in the [Fail] or [Partial] state.
 
       This function has no effect on the current state of the parser. *)


### PR DESCRIPTION
The docstring claimed to return `Some (bs, v)` when in reality it returns `Some v`.

Refs:
https://github.com/inhabitedtype/angstrom/blob/3a3e245b6f1b300faaf964629e089dca311dbf68/lib/angstrom.ml#L118-L120