### PR TITLE
Add parse_incomplete_bigstring

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -594,6 +594,10 @@ module Unbuffered : sig
   val parse : 'a t -> 'a state
   (** [parse t] runs [t] and await input if needed. *)
 
+  val parse_incomplete_bigstring : 'a t -> bigstring -> 'a state
+  (** [parse_incomplete_bigstring p x] runs [p] with {!Incomplete} input [x] and
+      await input if needed. *)
+
   val state_to_option : 'a state -> 'a option
   (** [state_to_option state] returns [Some (bs, v)] if the parser is in the
       [Done (bs, v)] state and [None] otherwise. This function has no effect on the

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -33,6 +33,10 @@ let parse p =
   let input = Input.create Bigstringaf.empty ~committed_bytes:0 ~off:0 ~len:0 in
   p.run input 0 Incomplete fail_k succeed_k
 
+let parse_incomplete_bigstring p input =
+  let input = Input.create input ~committed_bytes:0 ~off:0 ~len:(Bigstringaf.length input) in
+  p.run input 0 Incomplete fail_k succeed_k
+
 let parse_bigstring p input =
   let input = Input.create input ~committed_bytes:0 ~off:0 ~len:(Bigstringaf.length input) in
   state_to_result (p.run input 0 Complete fail_k succeed_k)


### PR DESCRIPTION
This code function is to able to replace this kind of bad code:

```ocaml
let[@warning "-8"] Angstrom.Unbuffered.Partial { continue; _ }= Angstrom.Unbuffered.parse p in
continue x ~off:0 ~len:(Bigstringaf.length x) Angstrom.Unbuffered.Incomplete
```