### PR TITLE
Fix `Angstrom.advance` to fail if the remaining input is less than n

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -228,7 +228,11 @@ let end_of_input =
 let advance n =
   if n < 0
   then fail "advance"
-  else { run = fun input pos more _fail succ -> succ input (pos + n) more () }
+  else
+    let p =
+      { run = fun input pos more _fail succ -> succ input (pos + n) more () }
+    in
+    ensure n p
 
 let pos =
   { run = fun input pos more _fail succ -> succ input pos more pos }

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -107,6 +107,11 @@ let basic_constructors =
       check_fail ~msg:"true, empty input"      (take_while1 (fun _ -> true)) [""];
       check_fail ~msg:"false, empty input"     (take_while1 (fun _ -> false)) [""];
   end
+  ; "advance", `Quick, begin fun () ->
+      check_s ~msg:"non-empty input"                (advance 3 >>= fun () -> take 1) ["asdf"] "f";
+      check_fail ~msg:"advance more than available" (advance 5) ["asdf"];
+      check_fail ~msg:"advance on empty input"      (advance 3) [""];
+  end
   ]
 
 module type EndianBigstring = sig


### PR DESCRIPTION
The `advance` docstring states that `advance` will fail if the remaining
input is less than `n`. However, it seems like this is not actually the
case in practice.

This PR proposes that `advance` abides by what's stated in the
docstring. In practice I was seeing Angstrom report that it consumed
more input than the available input length, which is what led to
`Bigstringaf.blit` getting a negative length (related PR:
https://github.com/inhabitedtype/bigstringaf/pull/25) happening in the
first place.