### PR TITLE
int8: add int8 constructor

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -319,6 +319,16 @@ let any_char =
   in
   ensure 1 p
 
+let int8 i =
+  let p =
+    { run = fun input pos more fail succ ->
+      let c = Char.code (Input.get_char input pos) in
+      if c = i land 0xff
+      then succ input (pos + 1) more c
+      else fail input pos more [] (Printf.sprintf "int8 %d" i) }
+  in
+  ensure 1 p
+
 let any_uint8 =
   let p =
     { run = fun input pos more _fail succ ->

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -179,6 +179,10 @@ val scan_string : 'state -> ('state -> char -> 'state option) -> string t
 (** [scan_string init f] Like [scan] but discards the final state and returns
     the accumulated string *)
 
+val int8 : int -> int t
+(** [int8 i] accepts one byte that matches the lower-order byte of [i] and 
+    returns unit. *)
+
 val any_uint8 : int t
 (** [any_uint8] accepts any byte and returns it as an unsigned int8. *)
 

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -55,6 +55,12 @@ let basic_constructors =
       check_fail ~msg:"'a' failure"   (char 'a') ["b"];
       check_fail ~msg:"empty buffer"  (char 'a') [""]
   end
+  ; "int8", `Quick, begin fun () ->
+    check_int  ~msg:"singleton 'a'" (int8 0x0061) ["a"]     0x61;
+    check_int  ~msg:"prefix 'a'"    (int8 0xff61) ["asdf"]  0x61;
+    check_fail ~msg:"'a' failure"   (int8 0xff61) ["b"];
+    check_fail ~msg:"empty buffer"  (int8 0xff61) [""];
+  end
   ; "not_char", `Quick, begin fun () ->
       check_c    ~msg:"not 'a' singleton" (not_char 'a') ["b"] 'b';
       check_c    ~msg:"not 'a' prefix"    (not_char 'a') ["baba"] 'b';


### PR DESCRIPTION
Equivalent to the `char` constructor but takes an int as an argument and uses its lower-order byte to match against the current byte in the input.