### PR TITLE
Input bugfix

### DIFF
--- a/lib/input.ml
+++ b/lib/input.ml
@@ -100,7 +100,7 @@ let count_while t pos ~f =
   let off    = offset_in_buffer t pos in
   let i      = ref off in
   let len    = t.len in
-  while !i < len && f (Bigstringaf.unsafe_get buffer !i) do 
+  while !i < off + len && f (Bigstringaf.unsafe_get buffer !i) do
     incr i
   done;
   !i - off

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -370,6 +370,22 @@ let choice_commit =
       (parse_string p "@@^");
   end ]
 
+let input = 
+  [ "non-zero offset", `Quick, begin fun () ->
+    let parser = take_while (fun _ -> true) in
+    match Angstrom.Unbuffered.parse parser with
+    | Done _ | Fail _ -> assert false
+    | Partial { continue; committed } ->
+      Alcotest.(check int) "committed is zero" 0 committed;
+      let state = continue (Bigstringaf.of_string "abcd" ~off:0 ~len:4) ~off:1 ~len:2 Complete in
+      Alcotest.(check (result string string))
+        "offset and length respected"
+        (Ok "bc")
+        (Angstrom.Unbuffered.state_to_result state);
+  end ]
+;;
+
+
 
 let () =
   Alcotest.run "test suite"
@@ -383,4 +399,5 @@ let () =
     ; "incremental input"     , incremental 
     ; "count_while regression", count_while_regression
     ; "choice and commit"     , choice_commit
+    ; "input"                 , input
   ]


### PR DESCRIPTION
Fix the bug reported in #180 and test it.

When an input is provided with a corresponding `off` and `len`, that means that `[off, off + len)` is the valid range of the input. The upper bound that the code was previously using was `len`, which was incorrect.