### PR TITLE
input-bugfix-take-2: proper bugfix

### DIFF
--- a/lib/input.ml
+++ b/lib/input.ml
@@ -99,8 +99,8 @@ let count_while t pos ~f =
   let buffer = t.buffer in
   let off    = offset_in_buffer t pos in
   let i      = ref off in
-  let len    = t.len in
-  while !i < off + len && f (Bigstringaf.unsafe_get buffer !i) do
+  let limit  = t.off + t.len in
+  while !i < limit && f (Bigstringaf.unsafe_get buffer !i) do
     incr i
   done;
   !i - off


### PR DESCRIPTION
This fixes the bug introduced by #181, which was a bugfix for a bug reported in #180.

Before #181, when a non-zero `off` into the current input buffer was provided, the loop was conservative in what it would consume: rather than attempting to consume characters in the range `[off, off + len)`, it would only consider the characters in the range `[0, len)`.

#181 changed this so that it considered the range `[off, idx + len)` where `idx` is the current position in the input buffer. This seemingly worked on simple parsers. However for more complex parsers this led to unsafe memory accesses when determining how much of the input to consume, and that resulted in a length that ran over the end of the input buffer. When an `take_while*` parser then tried to return the bytes to the user, a checked memory access would then fail.