### PR TITLE
Make [Angstrom.fix] friendly with js_of_ocaml

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -521,6 +521,7 @@ module Buffered : sig
 
   type 'a state =
     | Partial of ([ input | `Eof ] -> 'a state) (** The parser requires more input. *)
+    | Lazy    of 'a state Lazy.t
     | Done    of unconsumed * 'a (** The parser succeeded. *)
     | Fail    of unconsumed * string list * string (** The parser failed. *)
 
@@ -579,6 +580,7 @@ module Unbuffered : sig
 
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
+    | Lazy    of 'a state Lazy.t
     | Done    of int * 'a (** The parser succeeded, consuming specified bytes. *)
     | Fail    of int * string list * string (** The parser failed, consuming specified bytes. *)
   and 'a partial =

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -3,6 +3,11 @@
  (modules test_angstrom)
  (names test_angstrom))
 
+(executables
+ (libraries bigstringaf angstrom RFC7159)
+ (modules test_json)
+ (names test_json))
+
 (alias
  (name runtest)
  (package angstrom)

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -358,9 +358,9 @@ let count_while_regression =
       (take_while1 (fun _ -> true) <* end_of_input) ["asdf"; ""] "asdf";
   end ]
 
-let choice_commit = 
+let choice_commit =
   [ "", `Quick, begin fun () ->
-    let p = 
+    let p =
       choice  [ string "@@" *> commit *> char '*'
               ; string "@"  *> commit *> char '!' ]
     in
@@ -370,10 +370,11 @@ let choice_commit =
       (parse_string p "@@^");
   end ]
 
-let input = 
+let input =
   let test p input ~off ~len expect =
     match Angstrom.Unbuffered.parse p with
     | Done _ | Fail _ -> assert false
+    | Lazy _ -> assert false
     | Partial { continue; committed } ->
       Alcotest.(check int) "committed is zero" 0 committed;
       let bs = Bigstringaf.of_string input ~off:0 ~len:(String.length input) in
@@ -403,7 +404,7 @@ let () =
     ; "applicative interface" , applicative
     ; "alternative"           , alternative
     ; "combinators"           , combinators
-    ; "incremental input"     , incremental 
+    ; "incremental input"     , incremental
     ; "count_while regression", count_while_regression
     ; "choice and commit"     , choice_commit
     ; "input"                 , input

--- a/lib_test/test_json.ml
+++ b/lib_test/test_json.ml
@@ -13,7 +13,7 @@ let read f =
 ;;
 
 let () =
-  let twitter_big = read "benchmarks/data/twitter.json" in
+  let twitter_big = read Sys.argv.(1) in
   match Angstrom.(parse_bigstring RFC7159.json twitter_big) with
   | Ok _ -> ()
   | Error err -> failwith err

--- a/lib_test/test_json.ml
+++ b/lib_test/test_json.ml
@@ -1,0 +1,19 @@
+let read f =
+  try
+    let ic = open_in_bin f in
+    let n = in_channel_length ic in
+    let s = Bytes.create n in
+    really_input ic s 0 n;
+    close_in ic;
+    let b = Bigstringaf.create n in
+    Bigstringaf.blit_from_bytes s ~src_off:0 b ~dst_off:0 ~len:n;
+    b
+  with e ->
+    failwith (Printf.sprintf "Cannot read content of %s.\n%s" f (Printexc.to_string e))
+;;
+
+let () =
+  let twitter_big = read "benchmarks/data/twitter.json" in
+  match Angstrom.(parse_bigstring RFC7159.json twitter_big) with
+  | Ok _ -> ()
+  | Error err -> failwith err


### PR DESCRIPTION
It solves https://github.com/inhabitedtype/angstrom/issues/95

This is heavily inspired by @dinosaure and @SGrondin but tries to keep the performance of native code untouched.

cc @tyoverby

Json benchmark before
```
Estimated testing time 40s (4 benchmarks x 10s). Change using '-quota'.
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼────────────┤
│ twitter1    │     15.15us │     4.55kw │       6.16w │       6.16w │      0.14% │
│ twitter10   │    106.55us │    28.01kw │     161.12w │     161.12w │      0.95% │
│ twitter20   │    214.54us │    54.58kw │     594.46w │     594.46w │      1.92% │
│ twitter-big │ 11_170.42us │ 2_147.11kw │ 182_527.08w │ 182_527.08w │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴────────────┘
```

Json benchmark after
```
Estimated testing time 40s (4 benchmarks x 10s). Change using '-quota'.
┌─────────────┬─────────────┬────────────┬─────────────┬─────────────┬────────────┐
│ Name        │    Time/Run │    mWd/Run │    mjWd/Run │    Prom/Run │ Percentage │
├─────────────┼─────────────┼────────────┼─────────────┼─────────────┼────────────┤
│ twitter1    │     15.22us │     4.55kw │       6.16w │       6.16w │      0.14% │
│ twitter10   │    106.81us │    28.01kw │     160.67w │     160.67w │      0.96% │
│ twitter20   │    210.98us │    54.58kw │     594.89w │     594.89w │      1.89% │
│ twitter-big │ 11_158.23us │ 2_147.11kw │ 182_669.22w │ 182_669.22w │    100.00% │
└─────────────┴─────────────┴────────────┴─────────────┴─────────────┴────────────┘
```
With this PR, one can parse big json document in javascript, it would previously blowup.
```
dune build lib_test/test_json.bc.js
nodejs _build/default/lib_test/test_json.bc.js benchmarks/data/twitter.json
```