### PR TITLE
Make [Angstrom.fix] friendly with js_of_ocaml (Alternative to #186)

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -521,6 +521,7 @@ module Buffered : sig
 
   type 'a state =
     | Partial of ([ input | `Eof ] -> 'a state) (** The parser requires more input. *)
+    | Lazy    of 'a state Lazy.t
     | Done    of unconsumed * 'a (** The parser succeeded. *)
     | Fail    of unconsumed * string list * string (** The parser failed. *)
 
@@ -579,6 +580,7 @@ module Unbuffered : sig
 
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
+    | Lazy    of 'a state Lazy.t
     | Done    of int * 'a (** The parser succeeded, consuming specified bytes. *)
     | Fail    of int * string list * string (** The parser failed, consuming specified bytes. *)
   and 'a partial =

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -521,7 +521,6 @@ module Buffered : sig
 
   type 'a state =
     | Partial of ([ input | `Eof ] -> 'a state) (** The parser requires more input. *)
-    | Lazy    of 'a state Lazy.t
     | Done    of unconsumed * 'a (** The parser succeeded. *)
     | Fail    of unconsumed * string list * string (** The parser failed. *)
 
@@ -580,7 +579,6 @@ module Unbuffered : sig
 
   type 'a state =
     | Partial of 'a partial (** The parser requires more input. *)
-    | Lazy    of 'a state Lazy.t
     | Done    of int * 'a (** The parser succeeded, consuming specified bytes. *)
     | Fail    of int * string list * string (** The parser failed, consuming specified bytes. *)
   and 'a partial =

--- a/lib/exported_state.ml
+++ b/lib/exported_state.ml
@@ -1,0 +1,22 @@
+type 'a state =
+  | Partial of 'a partial
+  | Done    of int * 'a
+  | Fail    of int * string list * string
+
+and 'a partial =
+  { committed : int
+  ; continue  : Bigstringaf.t -> off:int -> len:int -> More.t -> 'a state }
+
+
+let state_to_option x = match x with
+  | Done(_, v) -> Some v
+  | Fail _     -> None
+  | Partial _  -> None
+
+let fail_to_string marks err =
+  String.concat " > " marks ^ ": " ^ err
+
+let state_to_result x = match x with
+  | Done(_, v)          -> Ok v
+  | Partial _           -> Error "incomplete input"
+  | Fail(_, marks, err) -> Error (fail_to_string marks err)

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -3,6 +3,11 @@
  (modules test_angstrom)
  (names test_angstrom))
 
+(executables
+ (libraries bigstringaf angstrom RFC7159)
+ (modules test_json)
+ (names test_json))
+
 (alias
  (name runtest)
  (package angstrom)

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -374,7 +374,6 @@ let input =
   let test p input ~off ~len expect =
     match Angstrom.Unbuffered.parse p with
     | Done _ | Fail _ -> assert false
-    | Lazy _ -> assert false
     | Partial { continue; committed } ->
       Alcotest.(check int) "committed is zero" 0 committed;
       let bs = Bigstringaf.of_string input ~off:0 ~len:(String.length input) in

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -358,9 +358,9 @@ let count_while_regression =
       (take_while1 (fun _ -> true) <* end_of_input) ["asdf"; ""] "asdf";
   end ]
 
-let choice_commit = 
+let choice_commit =
   [ "", `Quick, begin fun () ->
-    let p = 
+    let p =
       choice  [ string "@@" *> commit *> char '*'
               ; string "@"  *> commit *> char '!' ]
     in
@@ -370,10 +370,11 @@ let choice_commit =
       (parse_string p "@@^");
   end ]
 
-let input = 
+let input =
   let test p input ~off ~len expect =
     match Angstrom.Unbuffered.parse p with
     | Done _ | Fail _ -> assert false
+    | Lazy _ -> assert false
     | Partial { continue; committed } ->
       Alcotest.(check int) "committed is zero" 0 committed;
       let bs = Bigstringaf.of_string input ~off:0 ~len:(String.length input) in
@@ -403,7 +404,7 @@ let () =
     ; "applicative interface" , applicative
     ; "alternative"           , alternative
     ; "combinators"           , combinators
-    ; "incremental input"     , incremental 
+    ; "incremental input"     , incremental
     ; "count_while regression", count_while_regression
     ; "choice and commit"     , choice_commit
     ; "input"                 , input

--- a/lib_test/test_json.ml
+++ b/lib_test/test_json.ml
@@ -13,7 +13,7 @@ let read f =
 ;;
 
 let () =
-  let twitter_big = read "benchmarks/data/twitter.json" in
+  let twitter_big = read Sys.argv.(1) in
   match Angstrom.(parse_bigstring RFC7159.json twitter_big) with
   | Ok _ -> ()
   | Error err -> failwith err

--- a/lib_test/test_json.ml
+++ b/lib_test/test_json.ml
@@ -1,0 +1,19 @@
+let read f =
+  try
+    let ic = open_in_bin f in
+    let n = in_channel_length ic in
+    let s = Bytes.create n in
+    really_input ic s 0 n;
+    close_in ic;
+    let b = Bigstringaf.create n in
+    Bigstringaf.blit_from_bytes s ~src_off:0 b ~dst_off:0 ~len:n;
+    b
+  with e ->
+    failwith (Printf.sprintf "Cannot read content of %s.\n%s" f (Printexc.to_string e))
+;;
+
+let () =
+  let twitter_big = read "benchmarks/data/twitter.json" in
+  match Angstrom.(parse_bigstring RFC7159.json twitter_big) with
+  | Ok _ -> ()
+  | Error err -> failwith err


### PR DESCRIPTION
This is an alternative implementation to #186 that doesn't change the interface at the cost of translating between the internal and external state. I am not sure how to measure the impact of the additional allocation.
It seems to me that it would only matter for cases with lots of `Partial` state (e.g. feeding one char at a time).  
