### PR TITLE
expert: expose pos and available in the public API

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -620,9 +620,10 @@ module Unbuffered : sig
       This function has no effect on the current state of the parser. *)
 end
 
-(**/**)
+(** {2 Expert Parsers}
 
-(* These values are not part of the public API. *)
+    For people that know what they're doing. If you want to use them, read the
+    code. No further documentation will be provided. *)
 
 val pos : int t
 val available : int t


### PR DESCRIPTION
Any parser exposed in this section will be part of the public API but will not be documented. People that want to use them should read the code to fully understand what they're doing.

Caveat emptor for the whole library, but even moreso for this.

Closes #184.