### PR TITLE
[DRAFT] Added let-binding syntax introduced in 4.08.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ implementation of this example, see the documentation in the [`mli`][mli].
 
 [mli]: https://github.com/inhabitedtype/angstrom/blob/master/lib/angstrom.mli
 
+Support also exists for custom `let-binding` operators introduced
+from OCaml 4.08.0 onwards.
+
+```
+open Angstrom
+
+(* read a fixed length of bytes with a length prefix *)
+let bytes =
+  let* n = BE.any_int32 in
+  let* b = take_bigstring (Int32.to_int n) in
+  return b
+
+let integer =
+  let+ num = take_while (function '0'..'9' -> true | _ -> false) in
+  string_of_int num
+```
 
 ## Comparison to Other Libraries
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ open Angstrom
 (* read a fixed length of bytes with a length prefix *)
 let bytes =
   let* n = BE.any_int32 in
-  let* b = take_bigstring (Int32.to_int n) in
-  return b
+  let+ b = take_bigstring (Int32.to_int n) in
+  b
 
 let integer =
   let+ num = take_while (function '0'..'9' -> true | _ -> false) in

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -11,6 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
+  "cppo" {>= "1.0.0"}
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.0"}
   "alcotest" {with-test & >= "0.8.1"}

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -678,11 +678,13 @@ module LE = struct
     ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off)))
 end
 
+#if OCAML_VERSION >= (4,8,0)
 module Syntax = struct
   let (let*) = (>>=)
 
   let (let+) = (>>|)
 end
+#endif
 
 module Unsafe = struct
   let take n f =

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -678,6 +678,12 @@ module LE = struct
     ensure 8 (unsafe_apply 8 ~f:(fun bs ~off ~len:_ -> Int64.float_of_bits (Bigstringaf.unsafe_get_int64_le bs off)))
 end
 
+module Syntax = struct
+  let (let*) = (>>=)
+
+  let (let+) = (>>|)
+end
+
 module Unsafe = struct
   let take n f =
     let n = max n 0 in

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -445,6 +445,7 @@ val lift4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
     If the input buffer callback functions do not do any of these things, then
     the client may consider their use safe. *)
 
+#if OCAML_VERSION >= (4,8,0)
 (** let binding syntax introduced from 4.08.0 *)
 module Syntax : sig
   val (let*) : 'a t -> ('a -> 'b t) -> 'b t
@@ -453,6 +454,7 @@ module Syntax : sig
   val (let+) : 'a t -> ('a -> 'b) -> 'b t
   (** syntax for applicative bind *)
 end
+#endif
 
 module Unsafe : sig
 

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -444,6 +444,16 @@ val lift4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
 
     If the input buffer callback functions do not do any of these things, then
     the client may consider their use safe. *)
+
+(** let binding syntax introduced from 4.08.0 *)
+module Syntax : sig
+  val (let*) : 'a t -> ('a -> 'b t) -> 'b t
+  (** syntax for mondaic bind *)
+
+  val (let+) : 'a t -> ('a -> 'b) -> 'b t
+  (** syntax for applicative bind *)
+end
+
 module Unsafe : sig
 
   val take : int -> (bigstring -> off:int -> len:int -> 'a) -> 'a t

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,5 @@
  (name angstrom)
  (public_name angstrom)
  (libraries bigstringaf)
+ (preprocess (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
  (flags :standard -safe-string))


### PR DESCRIPTION
Inspired by the simliary syntax present in Lwt, I propose to add the same for monadic bind and applicative map to Angstrom.

Contributions - 
1. `Angstrom.Syntax` module with the `let*` and `let+` operators
2. Basic example in README.md on how to use

Questions -
1. As this feature was introduced in OCaml 4.08.0, there has to be a way to support the conditional compilation of this feature. The options are `cppo` and `ppx_optcomp`. Depending on the maintainer's choice, I can support for either of these.
2. Does this PR require tests? Given that I have only aliased a few operators, I do not feel the need for tests, but would be willing to add if required.