### PR TITLE
add both native and ppx let-syntax support, and corresponding tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - PINS="angstrom-async:. angstrom-lwt-unix:. angstrom:."
   - PACKAGE="angstrom"
   - TESTS=true
+  - EXTRA_DEPS="ppx_let"
   - POST_INSTALL_HOOK="opam install --with-test angstrom-async angstrom-lwt-unix && opam exec -- make examples"
   matrix:
   - OCAML_VERSION="4.08"

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -17,6 +17,7 @@ depends: [
   "bigstringaf"
   "result"
   "ppx_let" {with-test & >= "0.14.0"}
+  "ocaml-syntax-shims" {with-test}
 ]
 synopsis: "Parser combinators built for speed and memory-efficiency"
 description: """

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -17,7 +17,7 @@ depends: [
   "bigstringaf"
   "result"
   "ppx_let" {with-test & >= "0.14.0"}
-  "ocaml-syntax-shims" {with-test}
+  "ocaml-syntax-shims"
 ]
 synopsis: "Parser combinators built for speed and memory-efficiency"
 description: """

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -12,10 +12,11 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {>= "1.0"}
+  "dune" {>= "1.8"}
   "alcotest" {with-test & >= "0.8.1"}
   "bigstringaf"
   "result"
+  "ppx_let" {with-test & >= "0.14.0"}
 ]
 synopsis: "Parser combinators built for speed and memory-efficiency"
 description: """

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -17,7 +17,7 @@ depends: [
   "bigstringaf"
   "result"
   "ppx_let" {with-test & >= "0.14.0"}
-  "ocaml-syntax-shims"
+  "ocaml-syntax-shims" {build}
 ]
 synopsis: "Parser combinators built for speed and memory-efficiency"
 description: """

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 1.8)
 (name angstrom)

--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -571,6 +571,33 @@ let consume_with p f =
 let consumed           p = consume_with p Bigstringaf.substring
 let consumed_bigstring p = consume_with p Bigstringaf.copy
 
+let both a b = lift2 (fun a b -> a, b) a b
+let map t ~f = t >>| f
+let bind t ~f = t >>= f
+let map2 a b ~f = lift2 f a b
+let map3 a b c ~f = lift3 f a b c
+let map4 a b c d ~f = lift4 f a b c d
+
+module Let_syntax = struct
+  let return = return
+  let ( >>| ) = ( >>| )
+  let ( >>= ) = ( >>= )
+
+  module Let_syntax = struct
+    let return = return
+    let map = map
+    let bind = bind
+    let both = both
+    let map2 = map2
+    let map3 = map3
+    let map4 = map4
+  end
+end
+
+let ( let+ ) = ( >>| )
+let ( let* ) = ( >>= )
+let ( and+ ) = both
+
 module BE = struct
   (* XXX(seliopou): The pattern in both this module and [LE] are a compromise
    * between efficiency and code reuse. By inlining [ensure] you can recover

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -271,6 +271,10 @@ val option : 'a -> 'a t -> 'a t
 (** [option v p] runs [p], returning the result of [p] if it succeeds and [v]
     if it fails. *)
 
+
+val both : 'a t -> 'b t -> ('a * 'b) t
+(** [both p q] runs [p] followed by [q] and returns both results in a tuple *)
+
 val list : 'a t list -> 'a list t
 (** [list ps] runs each [p] in [ps] in sequence, returning a list of results of
     each [p]. *)
@@ -387,6 +391,9 @@ val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
 (** [p >>= f] creates a parser that will run [p], pass its result to [f], run
     the parser that [f] produces, and return its result. *)
 
+val bind : 'a t -> f:('a -> 'b t) -> 'b t
+(** [bind] is a prefix version of [>>=] *)
+
 val (>>|) : 'a t -> ('a -> 'b) -> 'b t
 (** [p >>| f] creates a parser that will run [p], and if it succeeds with
     result [v], will return [f v] *)
@@ -426,20 +433,12 @@ val lift4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
     Even with the partial application, it will be more efficient than the
     applicative implementation. *)
 
+val map : 'a t -> f:('a -> 'b) -> 'b t
 val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 val map3 : 'a t -> 'b t -> 'c t -> f:('a -> 'b -> 'c -> 'd) -> 'd t
 val map4 : 'a t -> 'b t -> 'c t -> 'd t -> f:('a -> 'b -> 'c -> 'd -> 'e) -> 'e t
 (** The [mapn] family of functions are just like [liftn], with a slightly
     different interface. *)
-
-val bind : 'a t -> f:('a -> 'b t) -> 'b t
-(** [bind] is a prefix version of [>>=] *)
-
-val map : 'a t -> f:('a -> 'b) -> 'b t
-(** [map] is a prefix version of [>>|] *)
-
-val both : 'a t -> 'b t -> ('a * 'b) t
-(** [both p q] runs [p] followed by [q] and returns both results in a tuple *)
 
 (** The [Let_syntax] module is intended to be used with the [ppx_let]
     pre-processor, and just contains copies of functions described elsewhere. *)

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -426,6 +426,42 @@ val lift4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
     Even with the partial application, it will be more efficient than the
     applicative implementation. *)
 
+val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+val map3 : 'a t -> 'b t -> 'c t -> f:('a -> 'b -> 'c -> 'd) -> 'd t
+val map4 : 'a t -> 'b t -> 'c t -> 'd t -> f:('a -> 'b -> 'c -> 'd -> 'e) -> 'e t
+(** The [mapn] family of functions are just like [liftn], with a slightly
+    different interface. *)
+
+val bind : 'a t -> f:('a -> 'b t) -> 'b t
+(** [bind] is a prefix version of [>>=] *)
+
+val map : 'a t -> f:('a -> 'b) -> 'b t
+(** [map] is a prefix version of [>>|] *)
+
+val both : 'a t -> 'b t -> ('a * 'b) t
+(** [both p q] runs [p] followed by [q] and returns both results in a tuple *)
+
+(** The [Let_syntax] module is intended to be used with the [ppx_let]
+    pre-processor, and just contains copies of functions described elsewhere. *)
+module Let_syntax : sig
+  val return : 'a -> 'a t
+  val ( >>| ) : 'a t -> ('a -> 'b) -> 'b t
+  val ( >>= ) : 'a t -> ('a -> 'b t) -> 'b t
+
+  module Let_syntax : sig
+    val return : 'a -> 'a t
+    val map : 'a t -> f:('a -> 'b) -> 'b t
+    val bind : 'a t -> f:('a -> 'b t) -> 'b t
+    val both : 'a t -> 'b t -> ('a * 'b) t
+    val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
+    val map3 : 'a t -> 'b t -> 'c t -> f:('a -> 'b -> 'c -> 'd) -> 'd t
+    val map4 : 'a t -> 'b t -> 'c t -> 'd t -> f:('a -> 'b -> 'c -> 'd -> 'e) -> 'e t
+  end
+end
+
+val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
+val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
+val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
 
 (** Unsafe Operations on Angstrom's Internal Buffer
 

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,5 @@
  (name angstrom)
  (public_name angstrom)
  (libraries bigstringaf)
- (flags :standard -safe-string))
+ (flags :standard -safe-string)
+ (preprocess future_syntax))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,15 @@
+(library
+ (name angstrom_test)
+ (libraries angstrom)
+ (flags :standard -safe-string)
+ (modules test_let_syntax_native test_let_syntax_ppx)
+ (preprocess
+  (per_module
+   (future_syntax test_let_syntax_native)
+   ((pps ppx_let) test_let_syntax_ppx))))
+
 (executables
- (libraries alcotest angstrom)
+ (libraries alcotest angstrom angstrom_test)
  (modules test_angstrom)
  (names test_angstrom))
 

--- a/lib_test/test_let_syntax_native.ml
+++ b/lib_test/test_let_syntax_native.ml
@@ -1,0 +1,11 @@
+open Angstrom
+
+let (_ : int t) =
+  let* () = end_of_input in
+  return 1
+
+let (_ : int t) =
+  let+ (_ : char) = any_char
+  and+ (_ : string) = string "foo"
+  in
+  2

--- a/lib_test/test_let_syntax_ppx.ml
+++ b/lib_test/test_let_syntax_ppx.ml
@@ -1,0 +1,18 @@
+open Angstrom
+open Let_syntax
+
+let (_ : int t) =
+  let%bind () = end_of_input in
+  return 1
+
+let (_ : int t) =
+  let%map (_ : char) = any_char
+  and (_ : string) = string "foo"
+  in
+  2
+
+let (_ : int t) =
+  let%mapn (_ : char) = any_char
+  and (_ : string) = string "foo"
+  in
+  2

--- a/lib_test/test_let_syntax_ppx.ml
+++ b/lib_test/test_let_syntax_ppx.ml
@@ -11,8 +11,12 @@ let (_ : int t) =
   in
   2
 
+(* [mapn] support was introduced in ppx_let.v0.14.0, which CI does not reliably
+  install. *)
+(*
 let (_ : int t) =
   let%mapn (_ : char) = any_char
   and (_ : string) = string "foo"
   in
   2
+*)


### PR DESCRIPTION
Notes:

I upgraded the minimum dune version from 1.0 to 1.8 in order to use the future_syntax preprocessor, which grant the native let-syntax backwards-compatibility to earlier compiler versions.  If you don't want that high of a dune requirement, we'll have to bail on native let-syntax.

The ppx_let version requirement is because that seems to be the first version that supports `let%mapn`.

For testing I just wanted to ensure a few things compile.  The way I did this was to have one of the test executables depend on the compilation of these two files I care about, even though it doesn't use them at all.  I couldn't come up with a better way to include building the library in the runtest alias, but I don't feel great about it.