### PR TITLE
opam: remove unneeded result dependency

### DIFF
--- a/angstrom.opam
+++ b/angstrom.opam
@@ -15,7 +15,6 @@ depends: [
   "dune" {>= "1.8"}
   "alcotest" {with-test & >= "0.8.1"}
   "bigstringaf"
-  "result"
   "ppx_let" {with-test & >= "0.14.0"}
   "ocaml-syntax-shims" {build}
 ]


### PR DESCRIPTION
Angstrom used to need the result compatibility package (for OCaml < 4.03).
Since Angstrom requires OCaml 4.04, there is no need for this extra dependency.