### PR TITLE
Remove an unwanted dependency toward the bigarray library in OCaml 4.07

### DIFF
--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -48,8 +48,7 @@ type +'a t
 (** A parser for values of type ['a]. *)
 
 
-type bigstring =
-  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type bigstring = Bigstringaf.t
 
 (** {2 Basic parsers} *)
 


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/pull/2041 for the fix in OCaml 4.08.0

Detected while running the tests for emile 0.2 to 0.5 on OCaml 4.07 in https://github.com/ocaml/opam-repository/pull/18758 (cc @dinosaure):
```
#=== ERROR while compiling emile.0.5 ==========================================#
# context              2.0.8 | linux/x86_64 | ocaml-base-compiler.4.07.1 | pinned(https://github.com/dinosaure/emile/releases/download/v0.5/emile-v0.5.tbz)
# path                 ~/.opam/4.07/.opam-switch/build/emile.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p emile -j 47
# exit-code            1
# env-file             ~/.opam/log/emile-19-9e3512.env
# output-file          ~/.opam/log/emile-19-9e3512.out
### output ###
#     ocamlopt test/test.exe (exit 2)
# (cd _build/default && /home/opam/.opam/4.07/bin/ocamlopt.opt -w -40 -w -14 -g -o test/test.exe /home/opam/.opam/4.07/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/4.07/lib/fmt/fmt.cmxa /home/opam/.opam/4.07/lib/astring/astring.cmxa /home/opam/.opam/4.07/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/4.07/lib/fmt/fmt_cli.cmxa /home/opam/.opam/4.07/lib/uuidm/uuidm.cmxa /home/opam/.opam/4.07/lib/re/re.cmxa /home/opam/.opam/4.07/lib/uutf/uutf.cmxa /home/opam/.opam/4.07/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/4.07/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.07/lib/ocaml /home/opam/.opam/4.07/lib/fmt/fmt_tty.cmxa /home/opam/.opam/4.07/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/4.07/lib/alcotest /home/opam/.opam/4.07/lib/base64/base64.cmxa /home/opam/.opam/4.07/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/4.07/lib/bigstringaf/bigstringaf.cmxa -I /home/opam/.opam/4.07/lib/bigstringaf /home/opam/.opam/4.07/lib/angstrom/angstrom.cmxa /home/opam/.opam/4.07/lib/pecu/pecu.cmxa /home/opam/.opam/4.07/lib/macaddr/macaddr.cmxa /home/opam/.opam/4.07/lib/domain-name/domain_name.cmxa /home/opam/.opam/4.07/lib/ipaddr/ipaddr.cmxa lib/emile.cmxa test/.test.eobjs/native/test.cmx)
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Bigarray referenced from lib/emile.cmxa(Emile)
```