### PR TITLE
exposed fix_lazy

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -461,8 +461,7 @@ let fix_direct f =
   in
   r
 
-let fix_lazy f =
-  let max_steps = 20 in
+let fix_lazy ?(max_steps=20) f =
   let steps = ref max_steps in
   let rec p = lazy (f r)
   and r = { run = fun buf pos more fail succ ->
@@ -480,7 +479,7 @@ let fix_lazy f =
 let fix = match Sys.backend_type with
   | Native -> fix_direct
   | Bytecode -> fix_direct
-  | Other _ -> fix_lazy
+  | Other _ -> fun f -> fix_lazy f
 
 let option x p =
   p <|> return x
@@ -493,9 +492,9 @@ let rec list ps =
   | p::ps -> lift2 cons p (list ps)
 
 let count n p =
-  if n < 0 
+  if n < 0
   then fail "count: n < 0"
-  else 
+  else
     let rec loop = function
       | 0 -> return []
       | n -> lift2 cons p (loop (n - 1))

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -348,6 +348,16 @@ val fix : ('a t -> 'a t) -> 'a t
     let obj = char '{' *> ... json ... <* char '}' in
     choice [str; num; arr json, ...])]} *)
 
+(** [fix_lazy] is like [fix], but after the function is
+    [max_steps] deep, it wraps up the remaining computation and yields
+    back to the root of the parsing loop where it continues from there.
+
+    This is an effective way to break up the stack trace into more managable
+    chunks, which is important for Js_of_ocaml due to the lack of tailrec
+    optimizations for CPS-style tail calls.  [max_steps] defaults to
+    [20], and when compiling for Js_of_ocaml, [fix] itself is defined as
+    [fix_lazy] set to [20]. *)
+val fix_lazy : ?max_steps:int-> ('a t -> 'a t) -> 'a t
 
 (** {2 Alternatives} *)
 


### PR DESCRIPTION
Exposed `fix_lazy`, which is useful for breaking up the stack trace into more managable chunks when the default of `max_steps = 20` steps is still too high for running in Js_of_ocaml