### PR TITLE
Add `backtrack` parser.

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -741,3 +741,9 @@ let parse_string ~consume p s =
   let bs  = Bigstringaf.create len in
   Bigstringaf.unsafe_blit_from_string s ~src_off:0 bs ~dst_off:0 ~len;
   parse_bigstring ~consume p bs
+
+let backtrack n =
+  { run = fun input pos more fail succ ->
+    if pos - n < Input.(parser_committed_bytes input)
+    then fail input pos more [] "not enough uncommited bytes to backtrack"
+    else succ input (pos - n) more () }

--- a/lib/angstrom.mli
+++ b/lib/angstrom.mli
@@ -686,3 +686,4 @@ end
 
 val pos : int t
 val available : int t
+val backtrack : int -> unit t

--- a/lib_test/test_angstrom.ml
+++ b/lib_test/test_angstrom.ml
@@ -432,6 +432,41 @@ let consume =
   ]
 ;;
 
+let backtrack =
+  let parse name p res =
+    let open Angstrom in
+    Alcotest.(check (result (string) string))
+      name
+      (parse_string ~consume:Prefix p "abcdef")
+      res
+  in
+  [ "backtrack 0 is nop", `Quick, begin fun () ->
+    parse
+      "backtracking works"
+      (char 'a' *> char 'b' *> backtrack 0 *> take 3)
+      (Ok "cde")
+  end;
+    "backtracking works", `Quick, begin fun () ->
+    parse
+      "backtracking works"
+      (char 'a' *> char 'b' *> backtrack 2 *> take 3)
+      (Ok "abc")
+  end;
+    "backtracking past beginning fails", `Quick, begin fun () ->
+    parse
+      "backtracking works"
+      (char 'a' *> char 'b' *> backtrack 3 *> take 3)
+      (Error ": not enough uncommited bytes to backtrack")
+  end;
+    "backtracking past commit point fails", `Quick, begin fun () ->
+    parse
+      "backtracking works"
+      (char 'a' *> commit *> char 'b' *> backtrack 2 *> take 3)
+      (Error ": not enough uncommited bytes to backtrack")
+  end
+  ]
+;;
+
 let () =
   Alcotest.run "test suite"
     [ "basic constructors"    , basic_constructors
@@ -446,4 +481,5 @@ let () =
     ; "choice and commit"     , choice_commit
     ; "input"                 , input
     ; "consume"               , consume
+    ; "backtrack"             , backtrack
   ]


### PR DESCRIPTION
# Feature

`backtrack n` is a parser that rewinds the input by `n` bytes, or fails if not enough client-uncommitted bytes are available. It is sorted with the expert, undocumented parser since it requires a good understanding of the input to be used safely.

I do understand that this feature may seem dangerous, yet I think it is legitimate and useful in some contexts (see rationale below). I would definitely understand if it's deemed too tricky to integrate upstream, I'm fine using our pinned version.

# Rationale

We use `Angstrom.scan` to consume UTF-8 input. Thus, we must sometime read multiple bytes to get an actual unicode character. If we then try to reject that character by returning `None`, only the last byte is pushed back to the input, losing some information and probably making the input malformed UTF-8. `backtrack` enables to roll back a few additional bytes to the start of the actual UTF-8 character. It is safe to use in such a case since we know there are at least that many uncommitted bytes to rollback.