### PR TITLE
Fix lift in debugging monad

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -163,7 +163,7 @@ module Monad_use_for_debugging = struct
   let (<$>) f m = m >>| f
   let (<*>) f m = f >>= fun f -> m >>| f
 
-  let lift  = (>>|)
+  let lift  = (<$>)
   let lift2 f m1 m2       = f <$> m1 <*> m2
   let lift3 f m1 m2 m3    = f <$> m1 <*> m2 <*> m3
   let lift4 f m1 m2 m3 m4 = f <$> m1 <*> m2 <*> m3 <*> m4


### PR DESCRIPTION
Hello, thanks for the great library.
It seems that the `lift` monad in `Monad_use_for_debugging` should be changed to `<$>` instead of `>>|`, based on the definition.
Please consider this change.
Thank you