### PR TITLE
raise lower OCaml bound to 4.08.0

### DIFF
--- a/angstrom-async.opam
+++ b/angstrom-async.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.8"}
   "angstrom" {>= "0.7.0"}
   "async" {>= "v0.10.0"}

--- a/angstrom-lwt-unix.opam
+++ b/angstrom-lwt-unix.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.8"}
   "angstrom"
   "lwt"

--- a/angstrom-unix.opam
+++ b/angstrom-unix.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.8"}
   "angstrom"
   "base-unix"

--- a/angstrom.opam
+++ b/angstrom.opam
@@ -11,12 +11,11 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.8"}
   "alcotest" {with-test & >= "0.8.1"}
   "bigstringaf"
   "ppx_let" {with-test & >= "v0.14.0"}
-  "ocaml-syntax-shims" {build}
 ]
 synopsis: "Parser combinators built for speed and memory-efficiency"
 description: """

--- a/async/dune
+++ b/async/dune
@@ -1,5 +1,4 @@
 (library
  (name angstrom_async)
  (public_name angstrom-async)
- (flags :standard -safe-string)
  (libraries angstrom async))

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,5 @@
 (library
  (name angstrom)
  (public_name angstrom)
- (libraries bigstringaf)
- (flags :standard -safe-string)
- (preprocess future_syntax))
+ (libraries bigstringaf))
+

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,7 +1,6 @@
 (library
  (name angstrom_test)
  (libraries angstrom)
- (flags :standard -safe-string)
  (modules test_let_syntax_native test_let_syntax_ppx)
  (preprocess
   (per_module

--- a/lwt/dune
+++ b/lwt/dune
@@ -1,5 +1,4 @@
 (library
  (name angstrom_lwt_unix)
  (public_name angstrom-lwt-unix)
- (flags :standard -safe-string)
  (libraries angstrom lwt.unix))


### PR DESCRIPTION
drop -safe-string (default since 4.06) from dune files