### PR TITLE
Remove Lazy from native and bytecode modes: not thread safe and sometimes SIGSEGV

### DIFF
--- a/lib/angstrom.ml
+++ b/lib/angstrom.ml
@@ -454,11 +454,14 @@ let take_till f =
 let choice ?(failure_msg="no more choices") ps =
   List.fold_right (<|>) ps (fail failure_msg)
 
+let notset = { run = fun _buf _pos _more _fail _succ -> failwith "Angstrom.fix_direct not set" }
+
 let fix_direct f =
-  let rec p = lazy (f r)
+  let rec p = ref notset
   and r = { run = fun buf pos more fail succ ->
-    (Lazy.force p).run buf pos more fail succ }
+    (!p).run buf pos more fail succ }
   in
+  p := f r;
   r
 
 let fix_lazy ~max_steps f =


### PR DESCRIPTION
Angstrom (and as a consequence Uri.of_string) is not thread-safe. On OCaml 4 this actually leads to a SIGSEGV sometimes, on OCaml 5 it raises CamlinternalLazy.Undefined.

This could be fixed by adding a 'Lazy.force p |> ignore' so that the Lazy value is never observable from a concurrent/parallel context, but I prefer to remove Lazy completely, at least until the reason for the OCaml 4 segfault is understood.

Using a ref here is safe, because the ref is only changed once before 'fix_direct' returns, so it is never changed from a concurrent/parallel context. And it still preserves the optimization that Lazy did: the fixpoint is only computed once.

This avoids the crash noticed in https://github.com/mirage/ocaml-uri/issues/178